### PR TITLE
Testingrefactor

### DIFF
--- a/examples/example_rc_filter.py
+++ b/examples/example_rc_filter.py
@@ -11,6 +11,9 @@ from io import BytesIO
 from ordec.core import *
 from ordec import Rational as R
 from ordec.lib.base import PulseVoltageSource, Res, Cap, Gnd
+from ordec.sim2.ngspice_ffi import NgspiceFFI
+# Ensure FFI library is checked early so linker/load errors are visible immediately.
+NgspiceFFI.find_library()
 from ordec.sim2.ngspice import Ngspice, NgspiceBackend
 from ordec.sim2.sim_hierarchy import SimHierarchy, HighlevelSim
 
@@ -239,11 +242,12 @@ def run_rc_square_wave_simulation_with_vcd():
     # Try to use FFI backend if available, otherwise subprocess
     backend_to_use = NgspiceBackend.SUBPROCESS
     try:
-        from ordec.sim2.ngspice import _FFIBackend
-        _FFIBackend.find_library()
+        from ordec.sim2.ngspice_ffi import NgspiceFFI
+        NgspiceFFI.find_library()
         backend_to_use = NgspiceBackend.FFI
         print("Using FFI backend for faster simulation")
-    except (ImportError, OSError):
+    except (ImportError, OSError) as e:
+        # Let errors be printed for easier debugging; fall back to subprocess backend
         print("Using subprocess backend")
 
     # Set backend for HighLevelSim

--- a/examples/example_rc_filter.py
+++ b/examples/example_rc_filter.py
@@ -250,7 +250,7 @@ def run_rc_square_wave_simulation_with_vcd():
     sim.backend = backend_to_use
 
     # Simulate for 5 periods to see the integration curve clearly
-    print("Running transient simulation for 5ms using HighLevelSim...")
+    print("Running transient simulation for 5m using HighLevelSim...")
     sim.tran("10u", "5m")
 
     time_data = s.time
@@ -268,7 +268,7 @@ def run_rc_square_wave_simulation_with_vcd():
     # Export to VCD using the new HighLevelSim method
     print("\nExporting simulation results to VCD format...")
     try:
-        vcd_success = sim.export_to_vcd("rc_simulation.vcd", timescale="1us")
+        vcd_success = sim.export_to_vcd("rc_simulation.vcd", timescale="1u")
     except Exception as e:
         print(f"Error during VCD export: {e}")
         return False

--- a/examples/interactive_rc_circuit.py
+++ b/examples/interactive_rc_circuit.py
@@ -283,13 +283,13 @@ class InteractiveSimulation:
     def stop_simulation(self):
         self.is_running = False
 
-    def start_vcd_recording(self, filename="interactive_simulation.vcd", timescale="1us"):
+    def start_vcd_recording(self, filename="interactive_simulation.vcd", timescale="1u"):
         """
         Start recording simulation data for VCD export with streaming to file.
 
         Args:
             filename: Output VCD filename
-            timescale: VCD timescale (e.g., "1us", "1ns")
+            timescale: VCD timescale (e.g., "1u", "1n")
         """
         try:
             self._vcd_file = open(filename, 'w')
@@ -403,7 +403,7 @@ class InteractiveSimulation:
 
                     self._vcd_file.write(f"r{value} {char}\n")
 
-    def export_to_vcd(self, filename="interactive_simulation.vcd", timescale="1us"):
+    def export_to_vcd(self, filename="interactive_simulation.vcd", timescale="1u"):
         return self.start_vcd_recording(filename, timescale)
 
 def main(plot_all_signals=False):
@@ -449,4 +449,4 @@ if __name__ == "__main__":
 
 InteractiveRCCircuit().schematic
 
-interactive_sim.start_vcd_recording("test.vcd") 
+interactive_sim.start_vcd_recording("test.vcd")

--- a/examples/interactive_rc_circuit.py
+++ b/examples/interactive_rc_circuit.py
@@ -14,6 +14,11 @@ from ordec.lib.base import Vdc, Res, Cap, Gnd
 from ordec.sim2.ngspice import Ngspice, NgspiceBackend
 from ordec.sim2.sim_hierarchy import SimHierarchy, HighlevelSim
 from ordec.widgets import AnimatedFnWidget, VdcSliderWidget
+from ordec.sim2.ngspice_ffi import NgspiceFFI
+
+# Ensure FFI library is checked early so errors are raised visibly during import.
+# This surfaces linker/load issues immediately and makes debugging simpler.
+NgspiceFFI.find_library()
 
 class InteractiveRCCircuit(Cell):
     vdc_initial = Parameter(R, default=R(1.0))
@@ -70,8 +75,7 @@ class InteractiveSimulation:
         self._vcd_header_buffer = []
         self._vcd_initial_values = []
 
-        from ordec.sim2.ngspice import _FFIBackend
-        _FFIBackend.find_library()
+        # FFI library is validated at module import time; no need to repeat here.
 
         self.vdc_slider.observe(self._on_voltage_change, names='value')
 

--- a/ordec/lib/test.py
+++ b/ordec/lib/test.py
@@ -1,39 +1,169 @@
 # SPDX-FileCopyrightText: 2025 ORDeC contributors
 # SPDX-License-Identifier: Apache-2.0
 
+from dataclasses import dataclass
+
 from .. import helpers
 from ..core import *
 from ..sim2.sim_hierarchy import HighlevelSim
+from ..sim2.ngspice_common import SignalKind, SignalArray
 
 from .generic_mos import Or2, Nmos, Pmos, Ringosc, Inv
 from .base import Gnd, NoConn, Res, Vdc, Idc, Cap, SinusoidalVoltageSource
 from . import sky130
 from . import ihp130
 
-# TranResult stores raw numeric values directly on attributes (no wrapper dataclasses)
+
+@dataclass
+class SignalValue:
+    value: float
+    kind: SignalKind
+
+    def get_vtype(self) -> int:
+        return self.kind.get_vtype_value()
+
+    def get_description(self) -> str:
+        return self.kind.get_description()
+
 
 class TranResult:
     def __init__(self, data_dict, sim_hierarchy, netlister, progress):
         self._data = data_dict
         self._node = sim_hierarchy
         self._netlister = netlister
-        self.time = data_dict.get('time', 0.0)
+        self.time = data_dict.get("time", 0.0)
         self.progress = progress
+
+        # Handle time signal separately
+        if "time" in data_dict:
+            self.__dict__["time"] = SignalValue(
+                value=data_dict["time"], kind=SignalKind.TIME
+            )
 
         # Create hierarchical access (nets)
         for net in sim_hierarchy.all(SimNet):
             net_name = netlister.name_hier_simobj(net)
-            if net_name in data_dict:
-                # Store raw numeric value directly (or None)
-                self.__dict__[net.npath.name] = data_dict[net_name]
+            if net_name in data_dict and net_name != "time":
+                # Store SignalValue struct containing both value and kind
+                self.__dict__[net.npath.name] = SignalValue(
+                    value=data_dict[net_name], kind=SignalKind.VOLTAGE
+                )
 
         # Create hierarchical access (instances)
         for inst in sim_hierarchy.all(SimInstance):
             inst_name = netlister.name_hier_simobj(inst)
             if inst_name in data_dict:
-                # Store instance value directly; consumers should treat it as a numeric value
-                _val = data_dict[inst_name]
-                self.__dict__[inst.npath.name] = _val
+                # Store SignalValue struct containing both value and kind
+                self.__dict__[inst.npath.name] = SignalValue(
+                    value=data_dict[inst_name], kind=SignalKind.CURRENT
+                )
+
+    def get_signal_kind(self, signal_name):
+        """Get the SignalKind enum for a given signal name."""
+        if hasattr(self, signal_name):
+            signal_value = getattr(self, signal_name)
+            if isinstance(signal_value, SignalValue):
+                return signal_value.kind
+        return SignalKind.OTHER
+
+    def get_signal_value(self, signal_name):
+        """Get the numeric value for a given signal name."""
+        if hasattr(self, signal_name):
+            signal_value = getattr(self, signal_name)
+            if isinstance(signal_value, SignalValue):
+                return signal_value.value
+        return None
+
+    def get_signal_vtype(self, signal_name):
+        """Get the ngspice v_type value by extracting it from the SignalKind enum."""
+        kind = self.get_signal_kind(signal_name)
+        return kind.get_vtype_value()
+
+    def get_signal_description(self, signal_name):
+        """Get a human-readable description by extracting it from the SignalKind enum."""
+        kind = self.get_signal_kind(signal_name)
+        return kind.get_description()
+
+    def get_signal_array(self, signal_name):
+        """Get a SignalArray for a given signal name (single value wrapped in array)."""
+        if signal_name in self._data:
+            kind = self.get_signal_kind(signal_name)
+            value = self.get_signal_value(signal_name)
+            return SignalArray(kind=kind, values=[value])
+        return None
+
+    def list_signals(self):
+        """List all available signal names."""
+        # Get signals from both _data and SignalValue attributes
+        signals = []
+        for attr_name, attr_value in self.__dict__.items():
+            if isinstance(attr_value, SignalValue):
+                signals.append(attr_name)
+        return signals
+
+    def list_signals_by_kind(self, kind):
+        """List signal names filtered by SignalKind."""
+        return [
+            name for name in self.list_signals() if self.get_signal_kind(name) == kind
+        ]
+
+    def list_signals_by_vtype(self, vtype):
+        """List signal names filtered by ngspice v_type value extracted from SignalKind enum."""
+        return [
+            name
+            for name in self.list_signals()
+            if self.get_signal_kind(name).get_vtype_value() == vtype
+        ]
+
+    def analyze_signal_types(self):
+        """Analyze and return signal type statistics using pattern matching."""
+        stats = {
+            "time_signals": [],
+            "voltage_signals": [],
+            "current_signals": [],
+            "other_signals": [],
+        }
+
+        for name in self.list_signals():
+            kind = self.get_signal_kind(name)
+            # Use pattern matching on the SignalKind enum itself
+            match kind:
+                case SignalKind.TIME:
+                    stats["time_signals"].append(name)
+                case SignalKind.VOLTAGE:
+                    stats["voltage_signals"].append(name)
+                case SignalKind.CURRENT:
+                    stats["current_signals"].append(name)
+                case SignalKind.OTHER:
+                    stats["other_signals"].append(name)
+
+        return stats
+
+    def get_signal_info(self, signal_name):
+        """Get comprehensive signal information using pattern matching."""
+        if not hasattr(self, signal_name) or not isinstance(
+            getattr(self, signal_name), SignalValue
+        ):
+            return None
+
+        kind = self.get_signal_kind(signal_name)
+        value = self.get_signal_value(signal_name)
+
+        # Extract data from the SignalKind enum using pattern matching
+        vtype, description = kind.match()
+
+        return {
+            "name": signal_name,
+            "value": value,
+            "vtype": vtype,
+            "description": description,
+            "kind": kind,
+            "is_time": kind.is_time(),
+            "is_voltage": kind.is_voltage(),
+            "is_current": kind.is_current(),
+            "is_other": kind.is_other(),
+        }
+
 
 class RotateTest(Cell):
     @generate
@@ -41,18 +171,29 @@ class RotateTest(Cell):
         s = Schematic(cell=self)
         c = Or2().symbol
 
-        s.R0   = SchemInstance(c.portmap(), pos=Vec2R(1, 1), orientation=Orientation.R0)
-        s.R90  = SchemInstance(c.portmap(), pos=Vec2R(12, 1), orientation=Orientation.R90)
-        s.R180 = SchemInstance(c.portmap(), pos=Vec2R(18, 6), orientation=Orientation.R180)
-        s.R270 = SchemInstance(c.portmap(), pos=Vec2R(19, 6), orientation=Orientation.R270)
+        s.R0 = SchemInstance(c.portmap(), pos=Vec2R(1, 1), orientation=Orientation.R0)
+        s.R90 = SchemInstance(
+            c.portmap(), pos=Vec2R(12, 1), orientation=Orientation.R90
+        )
+        s.R180 = SchemInstance(
+            c.portmap(), pos=Vec2R(18, 6), orientation=Orientation.R180
+        )
+        s.R270 = SchemInstance(
+            c.portmap(), pos=Vec2R(19, 6), orientation=Orientation.R270
+        )
 
-        s.MY   = SchemInstance(c.portmap(), pos=Vec2R(6, 7), orientation=Orientation.MY)
-        s.MY90 = SchemInstance(c.portmap(), pos=Vec2R(12, 12), orientation=Orientation.MY90)
-        s.MX   = SchemInstance(c.portmap(), pos=Vec2R(13, 12), orientation=Orientation.MX)
-        s.MX90 = SchemInstance(c.portmap(), pos=Vec2R(19, 7), orientation=Orientation.MX90)
+        s.MY = SchemInstance(c.portmap(), pos=Vec2R(6, 7), orientation=Orientation.MY)
+        s.MY90 = SchemInstance(
+            c.portmap(), pos=Vec2R(12, 12), orientation=Orientation.MY90
+        )
+        s.MX = SchemInstance(c.portmap(), pos=Vec2R(13, 12), orientation=Orientation.MX)
+        s.MX90 = SchemInstance(
+            c.portmap(), pos=Vec2R(19, 7), orientation=Orientation.MX90
+        )
 
         s.outline = Rect4R(lx=0, ly=0, ux=25, uy=13)
         return s
+
 
 class PortAlignTest(Cell):
     @generate
@@ -83,6 +224,7 @@ class PortAlignTest(Cell):
 
         s.outline = Rect4R(lx=0, ly=0, ux=8, uy=8)
         return s
+
 
 class TapAlignTest(Cell):
     @generate
@@ -117,6 +259,7 @@ class DFF(Cell):
 
         return s
 
+
 class MultibitReg_Arrays(Cell):
     bits = Parameter(int)
 
@@ -126,8 +269,8 @@ class MultibitReg_Arrays(Cell):
 
         s.vss = Pin(pintype=PinType.In, align=Orientation.South)
         s.vdd = Pin(pintype=PinType.In, align=Orientation.North)
-        s.mkpath('d')
-        s.mkpath('q')
+        s.mkpath("d")
+        s.mkpath("q")
         for i in range(self.bits):
             s.d[i] = Pin(pintype=PinType.In, align=Orientation.West)
             s.q[i] = Pin(pintype=PinType.Out, align=Orientation.East)
@@ -143,8 +286,8 @@ class MultibitReg_Arrays(Cell):
         s.vss = Net(pin=self.symbol.vss)
         s.vdd = Net(pin=self.symbol.vdd)
         s.clk = Net(pin=self.symbol.clk)
-        s.mkpath('d')
-        s.mkpath('q')
+        s.mkpath("d")
+        s.mkpath("q")
         s.mkpath("I")
 
         s.vss % SchemPort(pos=Vec2R(1, 0), align=Orientation.East)
@@ -153,24 +296,29 @@ class MultibitReg_Arrays(Cell):
         for i in range(self.bits):
             s.d[i] = Net(pin=self.symbol.d[i])
             s.q[i] = Net(pin=self.symbol.q[i])
-            s.I[i] = SchemInstance(DFF().symbol.portmap(
+            s.I[i] = SchemInstance(
+                DFF().symbol.portmap(
                     vss=s.vss,
                     vdd=s.vdd,
                     clk=s.clk,
                     d=s.d[i],
                     q=s.q[i],
-                ), pos=Vec2R(2, 3 + 8*i), orientation=Orientation.R0)
+                ),
+                pos=Vec2R(2, 3 + 8 * i),
+                orientation=Orientation.R0,
+            )
 
-            s.d[i] % SchemPort(pos=Vec2R(1, 5+8*i), align=Orientation.East)
-            s.d[i] % SchemWire(vertices=[Vec2R(1, 5+8*i), Vec2R(2, 5+8*i)])
-            s.q[i] % SchemPort(pos=Vec2R(9, 5+8*i), align=Orientation.West)
-            s.q[i] % SchemWire(vertices=[Vec2R(8, 5+8*i), Vec2R(9, 5+8*i)])
+            s.d[i] % SchemPort(pos=Vec2R(1, 5 + 8 * i), align=Orientation.East)
+            s.d[i] % SchemWire(vertices=[Vec2R(1, 5 + 8 * i), Vec2R(2, 5 + 8 * i)])
+            s.q[i] % SchemPort(pos=Vec2R(9, 5 + 8 * i), align=Orientation.West)
+            s.q[i] % SchemWire(vertices=[Vec2R(8, 5 + 8 * i), Vec2R(9, 5 + 8 * i)])
 
-        s.outline = Rect4R(lx=0, ly=0, ux=10, uy=2+8*self.bits)
+        s.outline = Rect4R(lx=0, ly=0, ux=10, uy=2 + 8 * self.bits)
 
         helpers.schem_check(s, add_conn_points=True, add_terminal_taps=True)
 
         return s
+
 
 class MultibitReg_ArrayOfStructs(Cell):
     bits = Parameter(int)
@@ -181,7 +329,7 @@ class MultibitReg_ArrayOfStructs(Cell):
 
         s.vss = Pin(pintype=PinType.In, align=Orientation.South)
         s.vdd = Pin(pintype=PinType.In, align=Orientation.North)
-        s.mkpath('bit')
+        s.mkpath("bit")
         for i in range(self.bits):
             s.bit.mkpath(i)
             s.bit[i].d = Pin(pintype=PinType.In, align=Orientation.West)
@@ -190,6 +338,7 @@ class MultibitReg_ArrayOfStructs(Cell):
         helpers.symbol_place_pins(s)
 
         return s
+
 
 class MultibitReg_StructOfArrays(Cell):
     bits = Parameter(int)
@@ -200,9 +349,9 @@ class MultibitReg_StructOfArrays(Cell):
 
         s.vss = Pin(pintype=PinType.In, align=Orientation.South)
         s.vdd = Pin(pintype=PinType.In, align=Orientation.North)
-        s.mkpath('data')
-        s.data.mkpath('d')
-        s.data.mkpath('q')
+        s.mkpath("data")
+        s.data.mkpath("d")
+        s.data.mkpath("q")
         for i in range(self.bits):
             s.data.d[i] = Pin(pintype=PinType.In, align=Orientation.West)
             s.data.q[i] = Pin(pintype=PinType.Out, align=Orientation.East)
@@ -210,6 +359,7 @@ class MultibitReg_StructOfArrays(Cell):
         helpers.symbol_place_pins(s)
 
         return s
+
 
 class TestNmosInv(Cell):
     """For testing schem_check."""
@@ -239,7 +389,6 @@ class TestNmosInv(Cell):
         s.vdd = Net(pin=self.symbol.vdd)
         s.vss = Net(pin=self.symbol.vss)
 
-
         nmos = Nmos(w=R("500n"), l=R("250n")).symbol
 
         portmap = nmos.portmap(s=s.vss, b=s.vss, g=s.a, d=s.y)
@@ -255,14 +404,18 @@ class TestNmosInv(Cell):
         elif self.variant == "portmap_bad_value":
             list(s.pd.conns)[0].there = 12345
 
-        s.pu = SchemInstance(nmos.portmap(d=s.vdd, b=s.vss, g=s.vdd, s=s.y), pos=Vec2R(3, 8))
-        if self.variant=="double_instance":
-            s.pu2 = SchemInstance(nmos.portmap(d=s.vdd, b=s.vss, g=s.vdd, s=s.y), pos=Vec2R(3, 8))
+        s.pu = SchemInstance(
+            nmos.portmap(d=s.vdd, b=s.vss, g=s.vdd, s=s.y), pos=Vec2R(3, 8)
+        )
+        if self.variant == "double_instance":
+            s.pu2 = SchemInstance(
+                nmos.portmap(d=s.vdd, b=s.vss, g=s.vdd, s=s.y), pos=Vec2R(3, 8)
+            )
 
         s.vdd % SchemPort(pos=Vec2R(1, 13), align=Orientation.East)
         s.vss % SchemPort(pos=Vec2R(1, 1), align=Orientation.East)
         s.a % SchemPort(pos=Vec2R(1, 4), align=Orientation.East)
-        if self.variant == 'incorrect_port_conn':
+        if self.variant == "incorrect_port_conn":
             s.vss % SchemPort(pos=Vec2R(9, 7), align=Orientation.West)
         else:
             s.y % SchemPort(pos=Vec2R(9, 7), align=Orientation.West)
@@ -271,26 +424,41 @@ class TestNmosInv(Cell):
             s.default_supply = s.vdd
             s.default_ground = s.vss
         else:
-            s.vss % SchemWire(vertices=[Vec2R(1, 1), Vec2R(5, 1), s.pd.pos + nmos.s.pos])
-            if self.variant == 'skip_single_pin':
+            s.vss % SchemWire(
+                vertices=[Vec2R(1, 1), Vec2R(5, 1), s.pd.pos + nmos.s.pos]
+            )
+            if self.variant == "skip_single_pin":
                 s.vss % SchemWire(vertices=[Vec2R(7, 4), Vec2R(8, 4)])
             else:
-                s.vss % SchemWire(vertices=[Vec2R(7, 4), Vec2R(8, 4), Vec2R(8, 10), Vec2R(7, 10)])
-            if self.variant not in ('net_partitioned', 'net_partitioned_tapped'):
+                s.vss % SchemWire(
+                    vertices=[Vec2R(7, 4), Vec2R(8, 4), Vec2R(8, 10), Vec2R(7, 10)]
+                )
+            if self.variant not in ("net_partitioned", "net_partitioned_tapped"):
                 s.vss % SchemWire(vertices=[Vec2R(8, 4), Vec2R(8, 1), Vec2R(5, 1)])
 
-            if self.variant == 'net_partitioned_tapped':
+            if self.variant == "net_partitioned_tapped":
                 s.vss % SchemTapPoint(pos=Vec2R(8, 4), align=Orientation.South)
                 s.vss % SchemTapPoint(pos=Vec2R(5, 1), align=Orientation.East)
 
-            if self.variant == 'vdd_bad_wiring':
+            if self.variant == "vdd_bad_wiring":
                 s.vdd % SchemWire(vertices=[Vec2R(1, 13), Vec2R(2, 13)])
-            elif self.variant != 'skip_vdd_wiring':
-                s.vdd % SchemWire(vertices=[Vec2R(1, 13), Vec2R(2, 13), Vec2R(5, 13), s.pu.pos + nmos.d.pos])
+            elif self.variant != "skip_vdd_wiring":
+                s.vdd % SchemWire(
+                    vertices=[
+                        Vec2R(1, 13),
+                        Vec2R(2, 13),
+                        Vec2R(5, 13),
+                        s.pu.pos + nmos.d.pos,
+                    ]
+                )
                 if self.variant == "terminal_multiple_wires":
-                    s.vdd % SchemWire(vertices=[Vec2R(1, 13), Vec2R(1, 10), Vec2R(3, 10)])
+                    s.vdd % SchemWire(
+                        vertices=[Vec2R(1, 13), Vec2R(1, 10), Vec2R(3, 10)]
+                    )
                 else:
-                    s.vdd % SchemWire(vertices=[Vec2R(2, 13), Vec2R(2, 10), Vec2R(3, 10)])
+                    s.vdd % SchemWire(
+                        vertices=[Vec2R(2, 13), Vec2R(2, 10), Vec2R(3, 10)]
+                    )
 
             if self.variant == "terminal_connpoint":
                 s.vdd % SchemConnPoint(pos=Vec2R(1, 13))
@@ -300,8 +468,13 @@ class TestNmosInv(Cell):
             if self.variant == "tap_short":
                 s.vss % SchemTapPoint(pos=Vec2R(5, 13))
 
-            if self.variant == 'poly_short':
-                s.vdd % SchemWire(vertices=[Vec2R(2, 10), Vec2R(2, 4),])
+            if self.variant == "poly_short":
+                s.vdd % SchemWire(
+                    vertices=[
+                        Vec2R(2, 10),
+                        Vec2R(2, 4),
+                    ]
+                )
 
             s.a % SchemWire(vertices=[Vec2R(1, 4), Vec2R(2, 4), Vec2R(3, 4)])
             s.y % SchemWire(vertices=[Vec2R(5, 6), Vec2R(5, 7), Vec2R(5, 8)])
@@ -318,11 +491,15 @@ class TestNmosInv(Cell):
         if self.variant == "unconnected_conn_point":
             s.y % SchemConnPoint(pos=Vec2R(4, 7))
 
-
         s.outline = Rect4R(lx=0, ly=1, ux=10, uy=13)
-        helpers.schem_check(s, add_conn_points=self.add_conn_points, add_terminal_taps=self.add_terminal_taps)
+        helpers.schem_check(
+            s,
+            add_conn_points=self.add_conn_points,
+            add_terminal_taps=self.add_terminal_taps,
+        )
 
         return s
+
 
 class RingoscTb(Cell):
     @generate
@@ -334,22 +511,22 @@ class RingoscTb(Cell):
         s.y = Net()
 
         vdc = Vdc().symbol
-        s.i0 = SchemInstance(pos=Vec2R(0, 2), ref=vdc,
-            portmap={vdc.m:s.vss, vdc.p:s.vdd})
+        s.i0 = SchemInstance(
+            pos=Vec2R(0, 2), ref=vdc, portmap={vdc.m: s.vss, vdc.p: s.vdd}
+        )
 
         ro = Ringosc().symbol
-        s.dut = SchemInstance(pos=Vec2R(5, 2), ref=ro,
-            portmap={ro.vdd:s.vdd, ro.vss:s.vss, ro.y:s.y})
+        s.dut = SchemInstance(
+            pos=Vec2R(5, 2), ref=ro, portmap={ro.vdd: s.vdd, ro.vss: s.vss, ro.y: s.y}
+        )
 
         nc = NoConn().symbol
-        s.i1 = SchemInstance(pos=Vec2R(10, 2), ref=nc,
-            portmap={nc.a:s.y})
+        s.i1 = SchemInstance(pos=Vec2R(10, 2), ref=nc, portmap={nc.a: s.y})
 
         g = Gnd().symbol
-        s.i2 = SchemInstance(pos=Vec2R(0, -4), ref=g,
-            portmap={g.p:s.vss})
+        s.i2 = SchemInstance(pos=Vec2R(0, -4), ref=g, portmap={g.p: s.vss})
 
-        #s.ref = self.symbol
+        # s.ref = self.symbol
 
         s.outline = Rect4R(lx=0, ly=-4, ux=15, uy=7)
 
@@ -366,8 +543,9 @@ class RingoscTb(Cell):
 # Cells for sim2 testing
 # ----------------------
 
+
 class SimBase(Cell):
-    backend = Parameter(str, default='subprocess')
+    backend = Parameter(str, default="subprocess")
 
     @generate
     def sim_hierarchy(self):
@@ -390,7 +568,15 @@ class SimBase(Cell):
         sim.ac(*args, **kwargs)
         return s
 
-    def sim_tran_async(self, tstep, tstop, callback=None, throttle_interval=0.1, enable_savecurrents=True, backend=None):
+    def sim_tran_async(
+        self,
+        tstep,
+        tstop,
+        callback=None,
+        throttle_interval=0.1,
+        enable_savecurrents=True,
+        backend=None,
+    ):
         """Run async transient simulation.
 
         Args:
@@ -405,13 +591,20 @@ class SimBase(Cell):
 
         node = SimHierarchy()
         hl_backend = backend if backend is not None else self.backend
-        highlevel_sim = HighlevelSim(self.schematic, node, enable_savecurrents=enable_savecurrents, backend=hl_backend)
+        highlevel_sim = HighlevelSim(
+            self.schematic,
+            node,
+            enable_savecurrents=enable_savecurrents,
+            backend=hl_backend,
+        )
 
         with Ngspice.launch(backend=hl_backend) as sim:
             sim.load_netlist(highlevel_sim.netlister.out())
 
             # Get the queue from the new queue-based tran_async
-            data_queue = sim.tran_async(tstep, tstop, throttle_interval=throttle_interval)
+            data_queue = sim.tran_async(
+                tstep, tstop, throttle_interval=throttle_interval
+            )
 
             # Convert queue-based approach to generator for API compatibility
             import queue
@@ -443,7 +636,9 @@ class SimBase(Cell):
                     status_future = executor.submit(check_simulation_status)
 
                     # Wait for either data or status with short timeout
-                    done_futures = concurrent.futures.as_completed([data_future, status_future], timeout=0.1)
+                    done_futures = concurrent.futures.as_completed(
+                        [data_future, status_future], timeout=0.1
+                    )
 
                     data_available = False
 
@@ -462,9 +657,14 @@ class SimBase(Cell):
                                     if isinstance(data_point, dict):
                                         if callback:
                                             callback(data_point)
-                                        data = data_point.get('data', {})
-                                        progress = data_point.get('progress', 0.0)
-                                        yield TranResult(data, node, highlevel_sim.netlister, progress)
+                                        data = data_point.get("data", {})
+                                        progress = data_point.get("progress", 0.0)
+                                        yield TranResult(
+                                            data,
+                                            node,
+                                            highlevel_sim.netlister,
+                                            progress,
+                                        )
 
                             elif future == status_future:
                                 is_running = future.result()
@@ -490,7 +690,9 @@ class SimBase(Cell):
                             if time.time() - completion_time >= fallback_grace_period:
                                 # Try to drain any remaining items quickly
                                 remaining_items = 0
-                                while remaining_items < 10:  # Limit to prevent infinite loop
+                                while (
+                                    remaining_items < 10
+                                ):  # Limit to prevent infinite loop
                                     try:
                                         data_point = data_queue.get_nowait()
                                         if data_point == "---ASYNC_SIM_SENTINEL---":
@@ -498,9 +700,14 @@ class SimBase(Cell):
                                         if isinstance(data_point, dict):
                                             if callback:
                                                 callback(data_point)
-                                            data = data_point.get('data', {})
-                                            progress = data_point.get('progress', 0.0)
-                                            yield TranResult(data, node, highlevel_sim.netlister, progress)
+                                            data = data_point.get("data", {})
+                                            progress = data_point.get("progress", 0.0)
+                                            yield TranResult(
+                                                data,
+                                                node,
+                                                highlevel_sim.netlister,
+                                                progress,
+                                            )
                                         remaining_items += 1
                                     except queue.Empty:
                                         break
@@ -508,8 +715,6 @@ class SimBase(Cell):
                         elif not sim.is_running():
                             # Just finished, start grace period
                             completion_time = time.time()
-
-
 
     def sim_tran(self, tstep, tstop, backend=None, **kwargs):
         """Run sync transient simulation.
@@ -522,11 +727,13 @@ class SimBase(Cell):
         """
         # Create hierarchical simulation
         from ..sim2.sim_hierarchy import SimHierarchy
+
         s = SimHierarchy(cell=self)
         chosen_backend = backend if backend is not None else self.backend
         sim = HighlevelSim(self.schematic, s, backend=chosen_backend, **kwargs)
         sim.tran(tstep, tstop)
         return s
+
 
 class RcFilterTb(SimBase):
     r = Parameter(R, default=R(1e3))
@@ -540,7 +747,9 @@ class RcFilterTb(SimBase):
         s.out = Net()
         s.vss = Net()
 
-        vac = SinusoidalVoltageSource(amplitude=R(1), frequency=R(1)).symbol # frequency is a dummy value
+        vac = SinusoidalVoltageSource(
+            amplitude=R(1), frequency=R(1)
+        ).symbol  # frequency is a dummy value
         res = Res(r=self.r).symbol
         cap = Cap(c=self.c).symbol
         gnd = Gnd().symbol
@@ -554,13 +763,16 @@ class RcFilterTb(SimBase):
         s.out % SchemWire(vertices=[s.I2.pos + res.m.pos, s.I3.pos + cap.p.pos])
 
         vss_bus_y = R(-2)
-        s.vss % SchemWire(vertices=[Vec2R(2, vss_bus_y), Vec2R(12, vss_bus_y)]) # vss bus
+        s.vss % SchemWire(
+            vertices=[Vec2R(2, vss_bus_y), Vec2R(12, vss_bus_y)]
+        )  # vss bus
         s.vss % SchemWire(vertices=[s.I0.pos + gnd.p.pos, Vec2R(2, vss_bus_y)])
         s.vss % SchemWire(vertices=[s.I1.pos + vac.m.pos, Vec2R(2, vss_bus_y)])
         s.vss % SchemWire(vertices=[s.I3.pos + cap.m.pos, Vec2R(12, vss_bus_y)])
 
         helpers.schem_check(s, add_conn_points=True)
         return s
+
 
 class ResdivFlatTb(SimBase):
     @generate
@@ -584,7 +796,9 @@ class ResdivFlatTb(SimBase):
 
         s.vss % SchemWire(vertices=[Vec2R(7, 4), Vec2R(7, 5), Vec2R(7, 6)])
         s.vss % SchemWire(vertices=[Vec2R(2, 6), Vec2R(2, 5), Vec2R(7, 5)])
-        s.vdd % SchemWire(vertices=[Vec2R(2, 10), Vec2R(2, 21), Vec2R(7, 21), Vec2R(7, 20)])
+        s.vdd % SchemWire(
+            vertices=[Vec2R(2, 10), Vec2R(2, 21), Vec2R(7, 21), Vec2R(7, 20)]
+        )
         s.a % SchemWire(vertices=[Vec2R(7, 10), Vec2R(7, 11)])
         s.b % SchemWire(vertices=[Vec2R(7, 15), Vec2R(7, 16)])
 
@@ -593,6 +807,7 @@ class ResdivFlatTb(SimBase):
         helpers.schem_check(s, add_conn_points=True)
 
         return s
+
 
 class ResdivHier2(Cell):
     r = Parameter(R)
@@ -625,7 +840,9 @@ class ResdivHier2(Cell):
 
         s.I0 = SchemInstance(sym_res.portmap(m=s.b, p=s.m), pos=Vec2R(0, 1))
         s.I1 = SchemInstance(sym_res.portmap(m=s.m, p=s.t), pos=Vec2R(0, 7))
-        s.I2 = SchemInstance(sym_res.portmap(m=s.r, p=s.m), pos=Vec2R(9, 4), orientation=Orientation.R90)
+        s.I2 = SchemInstance(
+            sym_res.portmap(m=s.r, p=s.m), pos=Vec2R(9, 4), orientation=Orientation.R90
+        )
 
         s.outline = Rect4R(lx=0, ly=0, ux=10, uy=12)
 
@@ -637,6 +854,7 @@ class ResdivHier2(Cell):
 
         helpers.schem_check(s, add_conn_points=True)
         return s
+
 
 class ResdivHier1(Cell):
     @generate
@@ -668,7 +886,7 @@ class ResdivHier1(Cell):
         sym_1 = ResdivHier2(r=R(100)).symbol
         sym_2 = ResdivHier2(r=R(200)).symbol
 
-        #s % SchemInstance(pos=Vec2R(5, 0), ref=sym_1, portmap={sym_1.t: s.m, sym_1.b:s.gnd, sym_1.r:s.br})
+        # s % SchemInstance(pos=Vec2R(5, 0), ref=sym_1, portmap={sym_1.t: s.m, sym_1.b:s.gnd, sym_1.r:s.br})
         s.I0 = SchemInstance(sym_1.portmap(t=s.m, b=s.b, r=s.br), pos=Vec2R(5, 0))
         s.I1 = SchemInstance(sym_2.portmap(t=s.t, b=s.m, r=s.tr), pos=Vec2R(5, 6))
         s.I2 = SchemInstance(sym_1.portmap(t=s.tr, b=s.br, r=s.r), pos=Vec2R(10, 3))
@@ -685,6 +903,7 @@ class ResdivHier1(Cell):
         helpers.schem_check(s, add_conn_points=True)
         return s
 
+
 class ResdivHierTb(SimBase):
     @generate
     def schematic(self):
@@ -694,9 +913,13 @@ class ResdivHierTb(SimBase):
         s.r = Net()
         s.gnd = Net()
 
-        s.I0 = SchemInstance(ResdivHier1().symbol.portmap(t=s.t, b=s.gnd, r=s.r), pos=Vec2R(5, 0))
+        s.I0 = SchemInstance(
+            ResdivHier1().symbol.portmap(t=s.t, b=s.gnd, r=s.r), pos=Vec2R(5, 0)
+        )
         s.I1 = SchemInstance(NoConn().symbol.portmap(a=s.r), pos=Vec2R(10, 0))
-        s.I2 = SchemInstance(Vdc(dc=R(1)).symbol.portmap(m=s.gnd, p=s.t), pos=Vec2R(0, 0))
+        s.I2 = SchemInstance(
+            Vdc(dc=R(1)).symbol.portmap(m=s.gnd, p=s.t), pos=Vec2R(0, 0)
+        )
         s.I3 = SchemInstance(Gnd().symbol.portmap(p=s.gnd), pos=Vec2R(0, -6))
 
         s.outline = Rect4R(lx=0, ly=-6, ux=14, uy=5)
@@ -708,6 +931,7 @@ class ResdivHierTb(SimBase):
 
         helpers.schem_check(s, add_conn_points=True)
         return s
+
 
 class NmosSourceFollowerTb(SimBase):
     """Nmos (generic_mos) source follower with optional parameter vin."""
@@ -724,18 +948,28 @@ class NmosSourceFollowerTb(SimBase):
         s.vss = Net()
         vin = self.vin
 
-        s.I0 = SchemInstance(Nmos(w=R('5u'), l=R('1u')).symbol.portmap(d=s.vdd, s=s.o, g=s.i, b=s.vss), pos=Vec2R(11, 12))
+        s.I0 = SchemInstance(
+            Nmos(w=R("5u"), l=R("1u")).symbol.portmap(d=s.vdd, s=s.o, g=s.i, b=s.vss),
+            pos=Vec2R(11, 12),
+        )
 
         s.I1 = SchemInstance(Gnd().symbol.portmap(p=s.vss), pos=Vec2R(11, 0))
-        s.I2 = SchemInstance(Vdc(dc=R('5')).symbol.portmap(m=s.vss, p=s.vdd), pos=Vec2R(0, 6))
-        s.I3 = SchemInstance(Vdc(dc=vin).symbol.portmap(m=s.vss, p=s.i), pos=Vec2R(5, 6))
-        s.I4 = SchemInstance(Idc(dc=R('5u')).symbol.portmap(m=s.vss, p=s.o), pos=Vec2R(11, 6))
+        s.I2 = SchemInstance(
+            Vdc(dc=R("5")).symbol.portmap(m=s.vss, p=s.vdd), pos=Vec2R(0, 6)
+        )
+        s.I3 = SchemInstance(
+            Vdc(dc=vin).symbol.portmap(m=s.vss, p=s.i), pos=Vec2R(5, 6)
+        )
+        s.I4 = SchemInstance(
+            Idc(dc=R("5u")).symbol.portmap(m=s.vss, p=s.o), pos=Vec2R(11, 6)
+        )
 
         s.outline = Rect4R(lx=0, ly=0, ux=16, uy=22)
 
         helpers.schem_check(s, add_conn_points=True, add_terminal_taps=True)
 
         return s
+
 
 class InvTb(SimBase):
     vin = Parameter(R, optional=True, default=R(0))
@@ -749,17 +983,24 @@ class InvTb(SimBase):
         s.vss = Net()
         vin = self.vin
 
-        s.I0 = SchemInstance(Inv().symbol.portmap(vdd = s.vdd, vss=s.vss, a=s.i, y=s.o), pos=Vec2R(11, 9))
+        s.I0 = SchemInstance(
+            Inv().symbol.portmap(vdd=s.vdd, vss=s.vss, a=s.i, y=s.o), pos=Vec2R(11, 9)
+        )
         s.I1 = SchemInstance(NoConn().symbol.portmap(a=s.o), pos=Vec2R(16, 9))
         s.I2 = SchemInstance(Gnd().symbol.portmap(p=s.vss), pos=Vec2R(11, 0))
-        s.I3 = SchemInstance(Vdc(dc=R('5')).symbol.portmap(m=s.vss, p = s.vdd), pos=Vec2R(0, 6))
-        s.I4 = SchemInstance(Vdc(dc=vin).symbol.portmap(m=s.vss, p = s.i), pos=Vec2R(5, 6))
+        s.I3 = SchemInstance(
+            Vdc(dc=R("5")).symbol.portmap(m=s.vss, p=s.vdd), pos=Vec2R(0, 6)
+        )
+        s.I4 = SchemInstance(
+            Vdc(dc=vin).symbol.portmap(m=s.vss, p=s.i), pos=Vec2R(5, 6)
+        )
 
         s.outline = Rect4R(lx=0, ly=0, ux=20, uy=14)
 
         helpers.schem_check(s, add_conn_points=True, add_terminal_taps=True)
 
         return s
+
 
 class InvSkyTb(SimBase):
     vin = Parameter(R, optional=True, default=R(0))
@@ -777,10 +1018,12 @@ class InvSkyTb(SimBase):
         sym_inv = sky130.Inv().symbol
         sym_nc = NoConn().symbol
         sym_gnd = Gnd().symbol
-        sym_vdc_vdd = Vdc(dc=R('5')).symbol
+        sym_vdc_vdd = Vdc(dc=R("5")).symbol
         sym_vdc_in = Vdc(dc=vin).symbol
 
-        s.i_inv = SchemInstance(sym_inv.portmap(vdd=s.vdd, vss=s.vss, a=s.i, y=s.o), pos=Vec2R(11, 9))
+        s.i_inv = SchemInstance(
+            sym_inv.portmap(vdd=s.vdd, vss=s.vss, a=s.i, y=s.o), pos=Vec2R(11, 9)
+        )
         s.i_nc = SchemInstance(sym_nc.portmap(a=s.o), pos=Vec2R(16, 9))
 
         s.i_gnd = SchemInstance(sym_gnd.portmap(p=s.vss), pos=Vec2R(11, 0))
@@ -792,6 +1035,7 @@ class InvSkyTb(SimBase):
         helpers.schem_check(s, add_conn_points=True, add_terminal_taps=True)
 
         return s
+
 
 class InvIhpTb(SimBase):
     vin = Parameter(R, optional=True, default=R(0))
@@ -809,10 +1053,12 @@ class InvIhpTb(SimBase):
         sym_inv = ihp130.Inv().symbol
         sym_nc = NoConn().symbol
         sym_gnd = Gnd().symbol
-        sym_vdc_vdd = Vdc(dc=R('5')).symbol
+        sym_vdc_vdd = Vdc(dc=R("5")).symbol
         sym_vdc_in = Vdc(dc=vin).symbol
 
-        s.i_inv = SchemInstance(sym_inv.portmap(vdd=s.vdd, vss=s.vss, a=s.i, y=s.o), pos=Vec2R(11, 9))
+        s.i_inv = SchemInstance(
+            sym_inv.portmap(vdd=s.vdd, vss=s.vss, a=s.i, y=s.o), pos=Vec2R(11, 9)
+        )
         s.i_nc = SchemInstance(sym_nc.portmap(a=s.o), pos=Vec2R(16, 9))
 
         s.i_gnd = SchemInstance(sym_gnd.portmap(p=s.vss), pos=Vec2R(11, 0))
@@ -837,9 +1083,15 @@ class RCAlterTestbench(Cell):
         s.vout = Net()
         s.gnd = Net()
 
-        s.v1 = SchemInstance(Vdc(dc=R(1)).symbol.portmap(p=s.vin, m=s.gnd), pos=Vec2R(0, 5))
-        s.r1 = SchemInstance(Res(r=R(1000)).symbol.portmap(p=s.vin, m=s.vout), pos=Vec2R(5, 5))
-        s.c1 = SchemInstance(Cap(c=R("1u")).symbol.portmap(p=s.vout, m=s.gnd), pos=Vec2R(8, 3))
+        s.v1 = SchemInstance(
+            Vdc(dc=R(1)).symbol.portmap(p=s.vin, m=s.gnd), pos=Vec2R(0, 5)
+        )
+        s.r1 = SchemInstance(
+            Res(r=R(1000)).symbol.portmap(p=s.vin, m=s.vout), pos=Vec2R(5, 5)
+        )
+        s.c1 = SchemInstance(
+            Cap(c=R("1u")).symbol.portmap(p=s.vout, m=s.gnd), pos=Vec2R(8, 3)
+        )
         s.gnd_conn = SchemInstance(Gnd().symbol.portmap(p=s.gnd), pos=Vec2R(0, 0))
 
         return s

--- a/ordec/lib/test.py
+++ b/ordec/lib/test.py
@@ -448,9 +448,6 @@ def stream_from_queue(simbase, sim, data_queue, highlevel_sim, node, callback):
     def check_simulation_status():
         return sim.is_running()
 
-    # Small helper to process a single data_point and produce either a TranResult
-    # or indicate sentinel/ignore. Returns a tuple (kind, payload, updated_last_progress)
-    # where kind is one of: "sentinel", "ignore", "result".
     def process_data_point(data_point, last_progress):
         # Handle MP backend sentinel
         if data_point == "---ASYNC_SIM_SENTINEL---":
@@ -484,10 +481,6 @@ def stream_from_queue(simbase, sim, data_queue, highlevel_sim, node, callback):
         )
         return ("result", tr, last_progress)
 
-    # Drain up to N remaining items quickly after simulation completion.
-    # Collect TranResult objects into a list and return a tuple (state, last_progress, results).
-    # state is either "done" or "sentinel". This avoids returning a generator whose
-    # return value would be available only via StopIteration.
     def drain_remaining_items(last_progress, max_items=10):
         results = []
         remaining_items = 0

--- a/ordec/sim2/ngspice.py
+++ b/ordec/sim2/ngspice.py
@@ -10,9 +10,9 @@ from typing import Iterator, Optional, Callable, Generator
 import numpy as np
 
 from ..core import *
-from .ngspice_ffi import _FFIBackend
-from .ngspice_subprocess import _SubprocessBackend
-from .ngspice_mp import IsolatedFFIBackend
+from .ngspice_ffi import NgspiceFFI
+from .ngspice_subprocess import NgspiceSubprocess
+from .ngspice_mp import NgspiceIsolatedFFI
 
 class NgspiceBackend(Enum):
     """Available NgSpice backend types."""
@@ -31,9 +31,9 @@ class Ngspice:
             print(f"[Ngspice] Using backend: {backend.value}")
 
         backend_class = {
-            NgspiceBackend.FFI: _FFIBackend,
-            NgspiceBackend.SUBPROCESS: _SubprocessBackend,
-            NgspiceBackend.MP: IsolatedFFIBackend,
+            NgspiceBackend.FFI: NgspiceFFI,
+            NgspiceBackend.SUBPROCESS: NgspiceSubprocess,
+            NgspiceBackend.MP: NgspiceIsolatedFFI,
         }[backend]
 
         with backend_class.launch(debug=debug) as backend_instance:

--- a/ordec/sim2/ngspice.py
+++ b/ordec/sim2/ngspice.py
@@ -59,8 +59,16 @@ class Ngspice:
     def ac(self, *args, **kwargs) -> 'NgspiceAcResult':
         return self._backend_impl.ac(*args, **kwargs)
 
-    def tran_async(self, *args, throttle_interval: float = 0.1) -> 'queue.Queue':
-        return self._backend_impl.tran_async(*args, throttle_interval=throttle_interval)
+    def tran_async(self, tstep, tstop=None, throttle_interval: float = 0.1) -> 'queue.Queue':
+        """
+        Start an asynchronous transient simulation.
+
+        New strict signature: explicit `tstep` and optional `tstop`. Any backend
+        that implements `tran_async` is expected to accept the same explicit
+        signature (tstep, tstop, ...) so the proxy forwards those parameters
+        directly to the backend implementation.
+        """
+        return self._backend_impl.tran_async(tstep, tstop, throttle_interval=throttle_interval)
 
     def op_async(self, callback: Optional[Callable] = None) -> Generator:
         if hasattr(self._backend_impl, 'op_async'):

--- a/ordec/sim2/ngspice_common.py
+++ b/ordec/sim2/ngspice_common.py
@@ -7,13 +7,18 @@ from enum import Enum
 from dataclasses import dataclass
 from typing import Dict
 
-NgspiceValue = namedtuple('NgspiceValue', ['type', 'name', 'subname', 'value'])
+NgspiceValue = namedtuple("NgspiceValue", ["type", "name", "subname", "value"])
+
 
 class SignalKind(Enum):
-    TIME = 1
-    VOLTAGE = 3
-    CURRENT = 4
-    OTHER = 99
+    TIME = (1, "time")
+    VOLTAGE = (3, "voltage")
+    CURRENT = (4, "current")
+    OTHER = (99, "other")
+
+    def __init__(self, vtype_value: int, description: str):
+        self.vtype_value = vtype_value
+        self.description = description
 
     @classmethod
     def from_vtype(cls, vtype: int):
@@ -26,35 +31,80 @@ class SignalKind(Enum):
 
         Falls back to OTHER for unknown values.
         """
-        if vtype == 1:
-            return cls.TIME
-        elif vtype == 3:
-            return cls.VOLTAGE
-        elif vtype == 4:
-            return cls.CURRENT
-        else:
-            return cls.OTHER
+        for kind in cls:
+            if vtype == kind.vtype_value:
+                return kind
+        return cls.OTHER
+
+    def get_vtype_value(self) -> int:
+        """Get the ngspice v_type value for this signal kind."""
+        return self.vtype_value
+
+    def get_description(self) -> str:
+        """Get a human-readable description of this signal kind."""
+        return self.description
+
+    def match(self) -> tuple[int, str]:
+        """Pattern matching helper: returns (vtype_value, description).
+
+        Usage example:
+            vtype, desc = signal_kind.match()
+            # or use pattern matching:
+            match signal_kind:
+                case SignalKind.TIME:
+                    print("This is a time signal")
+                case SignalKind.VOLTAGE:
+                    print("This is a voltage signal")
+                case SignalKind.CURRENT:
+                    print("This is a current signal")
+                case SignalKind.OTHER:
+                    print("This is an unknown signal type")
+        """
+        return (self.vtype_value, self.description)
+
+    def is_time(self) -> bool:
+        """Check if this signal kind represents time."""
+        return self is SignalKind.TIME
+
+    def is_voltage(self) -> bool:
+        """Check if this signal kind represents voltage."""
+        return self is SignalKind.VOLTAGE
+
+    def is_current(self) -> bool:
+        """Check if this signal kind represents current."""
+        return self is SignalKind.CURRENT
+
+    def is_other(self) -> bool:
+        """Check if this signal kind represents an unknown type."""
+        return self is SignalKind.OTHER
+
 
 @dataclass
 class SignalArray:
     kind: SignalKind
     values: list
 
+
 class NgspiceError(Exception):
     pass
+
 
 class NgspiceFatalError(NgspiceError):
     pass
 
+
 class NgspiceConfigError(NgspiceError):
     """Raised when backend configuration fails."""
+
     pass
+
 
 class NgspiceTable:
     def __init__(self, name):
         self.name = name
         self.headers = []
         self.data = []
+
 
 class NgspiceTransientResult:
     def __init__(self):
@@ -77,7 +127,7 @@ class NgspiceTransientResult:
         # Find time column (usually index 1, but could be elsewhere)
         time_idx = None
         for i, header in enumerate(table.headers):
-            if header.lower() == 'time':
+            if header.lower() == "time":
                 time_idx = i
                 break
 
@@ -100,7 +150,7 @@ class NgspiceTransientResult:
 
         # Extract signal data
         for i, header in enumerate(table.headers):
-            if header.lower() in ['index', 'time']:
+            if header.lower() in ["index", "time"]:
                 continue
 
             signal_name = header
@@ -124,16 +174,16 @@ class NgspiceTransientResult:
 
     def _categorize_signal(self, signal_name, signal_data):
         """Categorize signals into voltages, currents, and branches."""
-        if signal_name.startswith('@') and '[' in signal_name:
+        if signal_name.startswith("@") and "[" in signal_name:
             # Device current like "@m.xi0.mpd[id]"
-            device_part = signal_name.split('[')[0][1:]  # Remove @ and get device part
-            current_type = signal_name.split('[')[1].rstrip(']')  # Get current type
+            device_part = signal_name.split("[")[0][1:]  # Remove @ and get device part
+            current_type = signal_name.split("[")[1].rstrip("]")  # Get current type
             if device_part not in self.currents:
                 self.currents[device_part] = {}
             self.currents[device_part][current_type] = signal_data
-        elif signal_name.endswith('#branch'):
+        elif signal_name.endswith("#branch"):
             # Branch current like "vi3#branch"
-            branch_name = signal_name.replace('#branch', '')
+            branch_name = signal_name.replace("#branch", "")
             self.branches[branch_name] = signal_data
         else:
             # Regular node voltage
@@ -144,11 +194,11 @@ class NgspiceTransientResult:
         if not signal_name:
             return SignalKind.OTHER
         name = signal_name.lower()
-        if name in ('time', 'index'):
+        if name in ("time", "index"):
             return SignalKind.TIME
-        if signal_name.startswith('@') and '[' in signal_name:
+        if signal_name.startswith("@") and "[" in signal_name:
             return SignalKind.CURRENT
-        if signal_name.endswith('#branch'):
+        if signal_name.endswith("#branch"):
             return SignalKind.CURRENT
         # Fallback: treat as node voltage
         return SignalKind.VOLTAGE
@@ -172,7 +222,7 @@ class NgspiceTransientResult:
     def get_voltage(self, node_name):
         return self.voltages.get(node_name, [])
 
-    def get_current(self, device_name, current_type='id'):
+    def get_current(self, device_name, current_type="id"):
         device_currents = self.currents.get(device_name, {})
         return device_currents.get(current_type, [])
 
@@ -192,31 +242,91 @@ class NgspiceTransientResult:
         return list(self.branches.keys())
 
     def plot_signals(self, *signal_names):
-        result = {'time': self.time}
+        result = {"time": self.time}
         for name in signal_names:
             result[name] = self.get_signal(name)
         return result
 
+
 class NgspiceAcResult:
     def __init__(self):
         self.freq = []
-        self.voltages = {}
-        self.currents = {}
-        self.branches = {}
+        # Map signal name -> SignalArray
+        self.signals: Dict[str, SignalArray] = {}
+        # legacy buckets (kept for compatibility with higher-level code)
+        self.voltages: Dict[str, list] = {}
+        self.currents: Dict[str, Dict[str, list]] = {}
+        self.branches: Dict[str, list] = {}
 
     def _categorize_signal(self, signal_name, signal_data):
         """Categorize signals into voltages, currents, and branches."""
-        if signal_name.startswith('@') and '[' in signal_name:
-            device_part = signal_name.split('[')[0][1:]
-            current_type = signal_name.split('[')[1].rstrip(']')
+        if signal_name.startswith("@") and "[" in signal_name:
+            device_part = signal_name.split("[")[0][1:]
+            current_type = signal_name.split("[")[1].rstrip("]")
             if device_part not in self.currents:
                 self.currents[device_part] = {}
             self.currents[device_part][current_type] = signal_data
-        elif signal_name.endswith('#branch'):
-            branch_name = signal_name.replace('#branch', '')
+        elif signal_name.endswith("#branch"):
+            branch_name = signal_name.replace("#branch", "")
             self.branches[branch_name] = signal_data
         else:
             self.voltages[signal_name] = signal_data
+
+        # Also add to signals dictionary with best-effort kind classification
+        kind = self._guess_signal_kind(signal_name)
+        self.signals[signal_name] = SignalArray(kind=kind, values=signal_data)
+
+    def _guess_signal_kind(self, signal_name) -> SignalKind:
+        """Best-effort heuristic to classify a signal name into a SignalKind."""
+        if not signal_name:
+            return SignalKind.OTHER
+        name = signal_name.lower()
+        if name in ("frequency", "freq"):
+            return (
+                SignalKind.TIME
+            )  # Frequency is the independent variable in AC analysis
+        if signal_name.startswith("@") and "[" in signal_name:
+            return SignalKind.CURRENT
+        if signal_name.endswith("#branch"):
+            return SignalKind.CURRENT
+        # Fallback: treat as node voltage
+        return SignalKind.VOLTAGE
+
+    def __getitem__(self, key):
+        """Allow signal access."""
+        return self.get_signal(key)
+
+    def get_signal(self, signal_name):
+        return self.signals.get(signal_name, [])
+
+    def get_voltage(self, node_name):
+        return self.voltages.get(node_name, [])
+
+    def get_current(self, device_name, current_type="id"):
+        device_currents = self.currents.get(device_name, {})
+        return device_currents.get(current_type, [])
+
+    def get_branch_current(self, branch_name):
+        return self.branches.get(branch_name, [])
+
+    def list_signals(self):
+        return list(self.signals.keys())
+
+    def list_voltages(self):
+        return list(self.voltages.keys())
+
+    def list_currents(self):
+        return list(self.currents.keys())
+
+    def list_branches(self):
+        return list(self.branches.keys())
+
+    def plot_signals(self, *signal_names):
+        result = {"frequency": self.freq}
+        for name in signal_names:
+            result[name] = self.get_signal(name)
+        return result
+
 
 def check_errors(ngspice_out):
     """Helper function to raise NgspiceError in Python from "Error: ..."
@@ -224,7 +334,7 @@ def check_errors(ngspice_out):
     first_error_msg = None
     has_fatal_indicator = False
 
-    for line in ngspice_out.split('\n'):
+    for line in ngspice_out.split("\n"):
         if "no such vector" in line:
             # This error can occur when a simulation (like 'op') is run that doesn't
             # produce any plot output. It's not a fatal error, so we ignore it.

--- a/ordec/sim2/ngspice_ffi.py
+++ b/ordec/sim2/ngspice_ffi.py
@@ -27,7 +27,7 @@ from .ngspice_common import (
 from ..core import R
 
 
-class _FFIBackend:
+class NgspiceFFI:
     _instance = None
     """FFI backend for ngspice shared library.
 
@@ -40,7 +40,7 @@ class _FFIBackend:
 
     def __new__(cls, *args, **kwargs):
         if not cls._instance:
-            cls._instance = super(_FFIBackend, cls).__new__(cls)
+            cls._instance = super(NgspiceFFI, cls).__new__(cls)
         return cls._instance
 
     class NgComplex(ctypes.Structure):
@@ -156,7 +156,7 @@ class _FFIBackend:
     def launch(debug=False):
         backend = None
         try:
-            backend = _FFIBackend(debug=debug)
+            backend = NgspiceFFI(debug=debug)
             yield backend
         except NgspiceError as e:
             raise e
@@ -165,11 +165,11 @@ class _FFIBackend:
                 try:
                     backend.cleanup()
                 except:
-                    pass  # Ignore cleanup errors to prevent segfaults
+                    pass  # TODO
 
-    def cleanup(self):
-        # Skip calling quit to avoid memory corruption issues in ngspice FFI
-        # The shared library will be cleaned up when the process exits
+
+
+    def cleanup(self): #TODO
         pass
 
     def _send_char_handler(self, message: bytes, ident: int, user_data) -> int:

--- a/ordec/sim2/ngspice_ffi.py
+++ b/ordec/sim2/ngspice_ffi.py
@@ -89,17 +89,21 @@ class _FFIBackend:
 
     class VectorInfo(ctypes.Structure):
         pass
+
     PVectorInfo = ctypes.POINTER(VectorInfo)
     VectorInfo._fields_ = [
-        ("v_name", ctypes.c_char_p), ("v_type", ctypes.c_int),
-        ("v_flags", ctypes.c_short), ("v_realdata", ctypes.POINTER(ctypes.c_double)),
-        ("v_compdata", ctypes.POINTER(NgComplex)), ("v_length", ctypes.c_int),
+        ("v_name", ctypes.c_char_p),
+        ("v_type", ctypes.c_int),
+        ("v_flags", ctypes.c_short),
+        ("v_realdata", ctypes.POINTER(ctypes.c_double)),
+        ("v_compdata", ctypes.POINTER(NgComplex)),
+        ("v_length", ctypes.c_int),
     ]
 
     def __init__(self, debug: bool = False):
         self.debug = debug
         # The __init__ method is called every time, but we only initialize once.
-        if hasattr(self, '_initialized') and self._initialized:
+        if hasattr(self, "_initialized") and self._initialized:
             return
 
         self.lib = self.find_library()
@@ -115,6 +119,9 @@ class _FFIBackend:
         self._last_callback_time = 0.0
         self._async_data_queue = queue.Queue()
         self._simulation_info = None
+        self._last_progress = 0.0
+        self._data_points_sent = 0
+        self._sim_tstop = 0.0
 
         # Keep references to callbacks
         self._send_char_cb = self._SendChar(self._send_char_handler)
@@ -122,7 +129,9 @@ class _FFIBackend:
         self._exit_cb = self._ControlledExit(self._exit_handler)
         self._send_data_cb = self._SendData(self._send_data_handler)
         self._send_init_data_cb = self._SendInitData(self._send_init_data_handler)
-        self._bg_thread_running_cb = self._BGThreadRunning(self._bg_thread_running_handler)
+        self._bg_thread_running_cb = self._BGThreadRunning(
+            self._bg_thread_running_handler
+        )
 
         init_result = self.lib.ngSpice_Init(
             self._send_char_cb,
@@ -131,10 +140,12 @@ class _FFIBackend:
             self._send_data_cb,
             self._send_init_data_cb,
             self._bg_thread_running_cb,
-            None
+            None,
         )
         if init_result != 0:
-            raise NgspiceConfigError(f"Failed to initialize NgSpice FFI library (error code: {init_result}).")
+            raise NgspiceConfigError(
+                f"Failed to initialize NgSpice FFI library (error code: {init_result})."
+            )
         self._initialized = True
 
     @staticmethod
@@ -153,8 +164,6 @@ class _FFIBackend:
                 except:
                     pass  # Ignore cleanup errors to prevent segfaults
 
-
-
     def cleanup(self):
         # Skip calling quit to avoid memory corruption issues in ngspice FFI
         # The shared library will be cleaned up when the process exits
@@ -162,7 +171,7 @@ class _FFIBackend:
 
     def _send_char_handler(self, message: bytes, ident: int, user_data) -> int:
         if message:
-            msg_str = message.decode('utf-8', errors='ignore').strip()
+            msg_str = message.decode("utf-8", errors="ignore").strip()
             self._output_lines.append(msg_str)
             if self.debug:
                 print(f"[ngspice-ffi-out] {msg_str}")
@@ -199,7 +208,7 @@ class _FFIBackend:
                     vec_ptr = vec_data_content.vecsa[i]
                     if vec_ptr:
                         vec = vec_ptr.contents
-                        name = vec.name.decode('utf-8') if vec.name else f"vec_{i}"
+                        name = vec.name.decode("utf-8") if vec.name else f"vec_{i}"
 
                         if vec.is_complex:
                             value = complex(vec.creal, vec.cimag)
@@ -210,8 +219,8 @@ class _FFIBackend:
 
                 # Calculate progress based on simulation time if available
                 progress = 0.0
-                if 'time' in data_points and self._sim_tstop:
-                    sim_time = data_points['time']
+                if "time" in data_points and self._sim_tstop:
+                    sim_time = data_points["time"]
                     progress = min(max(sim_time / self._sim_tstop, 0.0), 1.0)
                     # Ensure progress is monotonic
                     progress = max(progress, self._last_progress)
@@ -226,22 +235,26 @@ class _FFIBackend:
                 # Store in queue for safe retrieval
                 if data_points:
                     try:
-                        self._async_data_queue.put_nowait({
-                            'timestamp': current_time,
-                            'data': data_points,
-                            'index': vec_count,
-                            'progress': progress
-                        })
+                        self._async_data_queue.put_nowait(
+                            {
+                                "timestamp": current_time,
+                                "data": data_points,
+                                "index": vec_count,
+                                "progress": progress,
+                            }
+                        )
                     except queue.Full:
                         # Drop oldest data if queue is full
                         try:
                             self._async_data_queue.get_nowait()
-                            self._async_data_queue.put_nowait({
-                                'timestamp': current_time,
-                                'data': data_points,
-                                'index': vec_count,
-                                'progress': progress
-                            })
+                            self._async_data_queue.put_nowait(
+                                {
+                                    "timestamp": current_time,
+                                    "data": data_points,
+                                    "index": vec_count,
+                                    "progress": progress,
+                                }
+                            )
                         except queue.Empty:
                             pass
 
@@ -249,7 +262,10 @@ class _FFIBackend:
             # NEVER raise exceptions in C callbacks - just log if debug is on
             if self.debug:
                 import traceback
-                print(f"[ngspice-ffi] Error in _send_data_handler: {traceback.format_exc()}")
+
+                print(
+                    f"[ngspice-ffi] Error in _send_data_handler: {traceback.format_exc()}"
+                )
 
         return 0
 
@@ -260,12 +276,20 @@ class _FFIBackend:
                 vec_info_content = vec_info.contents
 
                 simulation_info = {
-                    'name': vec_info_content.name.decode('utf-8') if vec_info_content.name else 'unknown',
-                    'title': vec_info_content.title.decode('utf-8') if vec_info_content.title else '',
-                    'date': vec_info_content.date.decode('utf-8') if vec_info_content.date else '',
-                    'type': vec_info_content.type.decode('utf-8') if vec_info_content.type else '',
-                    'veccount': vec_info_content.veccount,
-                    'vectors': []
+                    "name": vec_info_content.name.decode("utf-8")
+                    if vec_info_content.name
+                    else "unknown",
+                    "title": vec_info_content.title.decode("utf-8")
+                    if vec_info_content.title
+                    else "",
+                    "date": vec_info_content.date.decode("utf-8")
+                    if vec_info_content.date
+                    else "",
+                    "type": vec_info_content.type.decode("utf-8")
+                    if vec_info_content.type
+                    else "",
+                    "veccount": vec_info_content.veccount,
+                    "vectors": [],
                 }
 
                 # Extract vector information
@@ -273,22 +297,30 @@ class _FFIBackend:
                     vec_ptr = vec_info_content.vecs[i]
                     if vec_ptr:
                         vec = vec_ptr.contents
-                        simulation_info['vectors'].append({
-                            'number': vec.number,
-                            'name': vec.vecname.decode('utf-8') if vec.vecname else f'vec_{i}',
-                            'is_real': bool(vec.is_real)
-                        })
+                        vector_info = {
+                            "number": vec.number,
+                            "name": vec.vecname.decode("utf-8")
+                            if vec.vecname
+                            else f"vec_{i}",
+                            "is_real": bool(vec.is_real),
+                        }
+                        simulation_info["vectors"].append(vector_info)
 
                 self._simulation_info = simulation_info
 
                 if self.debug:
-                    print(f"[ngspice-ffi] Simulation initialized: {simulation_info['name']} with {simulation_info['veccount']} vectors")
+                    print(
+                        f"[ngspice-ffi] Simulation initialized: {simulation_info['name']} with {simulation_info['veccount']} vectors"
+                    )
 
         except Exception:
             # NEVER raise exceptions in C callbacks
             if self.debug:
                 import traceback
-                print(f"[ngspice-ffi] Error in _send_init_data_handler: {traceback.format_exc()}")
+
+                print(
+                    f"[ngspice-ffi] Error in _send_init_data_handler: {traceback.format_exc()}"
+                )
 
         return 0
 
@@ -304,16 +336,23 @@ class _FFIBackend:
             # NEVER raise exceptions in C callbacks
             if self.debug:
                 import traceback
-                print(f"[ngspice-ffi] Error in _bg_thread_running_handler: {traceback.format_exc()}")
+
+                print(
+                    f"[ngspice-ffi] Error in _bg_thread_running_handler: {traceback.format_exc()}"
+                )
 
         return 0
 
     def _send_stat_handler(self, status: bytes, ident: int, user_data) -> int:
         if self.debug and status:
-            print(f"[ngspice-ffi-stat] {status.decode('utf-8', errors='ignore').strip()}")
+            print(
+                f"[ngspice-ffi-stat] {status.decode('utf-8', errors='ignore').strip()}"
+            )
         return 0
 
-    def _exit_handler(self, status: int, unload: bool, quit_upon_exit: bool, ident: int, user_data) -> int:
+    def _exit_handler(
+        self, status: int, unload: bool, quit_upon_exit: bool, ident: int, user_data
+    ) -> int:
         if status != 0 and self.debug:
             print(f"[ngspice-ffi-exit] code {status}")
         return status
@@ -322,7 +361,7 @@ class _FFIBackend:
         self._output_lines.clear()
         self._error_message = None
         self._has_fatal_error = False
-        ret = self.lib.ngSpice_Command(command.encode('utf-8'))
+        ret = self.lib.ngSpice_Command(command.encode("utf-8"))
 
         # Check for errors stored by callbacks (safe to raise exceptions here)
         if self._error_message:
@@ -365,7 +404,9 @@ class _FFIBackend:
         self._error_message = None
         self._has_fatal_error = False
 
-        circuit_lines = [line.encode('utf-8') for line in netlist.split('\n') if line.strip()]
+        circuit_lines = [
+            line.encode("utf-8") for line in netlist.split("\n") if line.strip()
+        ]
         c_circuit = (ctypes.c_char_p * len(circuit_lines))()
         c_circuit[:] = circuit_lines
 
@@ -383,7 +424,9 @@ class _FFIBackend:
         check_errors(output)
 
         if circ_result != 0:
-            raise NgspiceFatalError(f"Failed to load circuit into FFI backend. Full output:\n{output}")
+            raise NgspiceFatalError(
+                f"Failed to load circuit into FFI backend. Full output:\n{output}"
+            )
 
     def op(self) -> Iterator[NgspiceValue]:
         self.command("op")
@@ -397,110 +440,92 @@ class _FFIBackend:
             value = vec_info.v_realdata[0]
 
             # Match naming conventions from subprocess backend
-            if vec_name.startswith('@') and '[' in vec_name:
-                match = re.match(r"@([a-zA-Z]\.)?([0-9a-zA-Z_.#]+)\[([0-9a-zA-Z_]+)\]", vec_name)
+            if vec_name.startswith("@") and "[" in vec_name:
+                match = re.match(
+                    r"@([a-zA-Z]\.)?([0-9a-zA-Z_.#]+)\[([0-9a-zA-Z_]+)\]", vec_name
+                )
                 if match:
-                    yield NgspiceValue('current', match.group(2), match.group(3), value)
-            elif vec_name.endswith('#branch'):
-                yield NgspiceValue('current', vec_name.replace('#branch', ''), 'branch', value)
+                    yield NgspiceValue("current", match.group(2), match.group(3), value)
+            elif vec_name.endswith("#branch"):
+                yield NgspiceValue(
+                    "current", vec_name.replace("#branch", ""), "branch", value
+                )
             else:
-                yield NgspiceValue('voltage', vec_name, None, value)
+                yield NgspiceValue("voltage", vec_name, None, value)
 
     def tran(self, *args) -> NgspiceTransientResult:
         self.command(f"tran {' '.join(args)}")
         result = NgspiceTransientResult()
-        table = NgspiceTable("transient_analysis")
 
         all_vectors = self._get_all_vectors()
 
-        num_points = 0
-
-        # Get all vector data and structure it by column, filtering out zero-length vectors
-        vector_data_map = {}
-        valid_headers = []
-        vec_kind_map = {}
+        # Get all vector data and determine signal kinds from v_type
         for vec_name in all_vectors:
             vec_info = self._get_vector_info(vec_name)
             if vec_info and vec_info.v_length > 0:
-                num_points = max(num_points, vec_info.v_length)
                 data_list = [vec_info.v_realdata[i] for i in range(vec_info.v_length)]
-                vector_data_map[vec_name] = data_list
-                valid_headers.append(vec_name)
+
+                # Use v_type reported by ngspice for direct signal classification
                 try:
-                    # Use v_type reported by ngspice when available for robust classification
-                    vec_kind_map[vec_name] = SignalKind.from_vtype(int(vec_info.v_type))
+                    kind = SignalKind.from_vtype(int(vec_info.v_type))
                 except Exception:
-                    # If mapping fails, leave classification to the higher-level guesser
-                    pass
+                    # If mapping fails, fall back to heuristic classification
+                    kind = result._guess_signal_kind(vec_name)
 
-        table.headers = valid_headers
+                # Create SignalArray directly with the determined kind
+                result.signals[vec_name] = SignalArray(kind=kind, values=data_list)
 
-        # Transpose columns into rows
-        for i in range(num_points):
-            row = [vector_data_map[h][i] for h in table.headers]
-            table.data.append(row)
+                # Also categorize into legacy buckets for compatibility
+                result._categorize_signal(vec_name, data_list)
 
-        result.add_table(table)
-
-        # If we determined exact vector kinds from ngspice, override guessed kinds
-        try:
-            for name, kind in vec_kind_map.items():
-                if name in result.signals:
-                    result.signals[name].kind = kind
-        except NameError:
-            # vec_kind_map not defined; nothing to override
-            pass
+                # Handle time vector separately
+                if vec_name.lower() == "time":
+                    result.time = data_list
 
         return result
 
-    def ac(self, *args, **kwargs) -> 'NgspiceAcResult':
+    def ac(self, *args, **kwargs) -> "NgspiceAcResult":
         self.command(f"ac {' '.join(args)}")
         result = NgspiceAcResult()
 
         all_vectors = self._get_all_vectors()
 
-        num_points = 0
-        vector_data_map = {}
-        valid_headers = []
-
-        vec_kind_map = {}
         for vec_name in all_vectors:
             vec_info = self._get_vector_info(vec_name)
             if vec_info and vec_info.v_length > 0:
-                num_points = max(num_points, vec_info.v_length)
                 if vec_info.v_compdata:
-                    data_list = [complex(vec_info.v_compdata[i].cx_real, vec_info.v_compdata[i].cx_imag) for i in range(vec_info.v_length)]
+                    data_list = [
+                        complex(
+                            vec_info.v_compdata[i].cx_real,
+                            vec_info.v_compdata[i].cx_imag,
+                        )
+                        for i in range(vec_info.v_length)
+                    ]
                 else:
-                    data_list = [vec_info.v_realdata[i] for i in range(vec_info.v_length)]
-                vector_data_map[vec_name] = data_list
-                valid_headers.append(vec_name)
+                    data_list = [
+                        vec_info.v_realdata[i] for i in range(vec_info.v_length)
+                    ]
+
+                # Use v_type reported by ngspice for direct signal classification
                 try:
-                    vec_kind_map[vec_name] = SignalKind.from_vtype(int(vec_info.v_type))
+                    kind = SignalKind.from_vtype(int(vec_info.v_type))
                 except Exception:
-                    pass
+                    # If mapping fails, fall back to heuristic classification
+                    kind = result._guess_signal_kind(vec_name)
 
-        if 'frequency' in vector_data_map:
-            result.freq = tuple(vector_data_map['frequency'])
+                # Create SignalArray directly with the determined kind
+                result.signals[vec_name] = SignalArray(kind=kind, values=data_list)
 
-        for name, value in vector_data_map.items():
-            if name != 'frequency':
-                result._categorize_signal(name, value)
+                # Also categorize into legacy buckets for compatibility
+                result._categorize_signal(vec_name, data_list)
 
-        # Populate a signals mapping with SignalArray wrappers using v_type when available
-        try:
-            for name, value in vector_data_map.items():
-                if name == 'frequency':
-                    continue
-                kind = vec_kind_map.get(name, SignalKind.VOLTAGE)
-                # Attach SignalArray entries to result for richer typing
-                result.signals[name] = SignalArray(kind=kind, values=value)
-        except Exception:
-            # Best-effort: do not break AC processing if SignalArray construction fails
-            pass
+                # Handle frequency vector separately
+                if vec_name.lower() in ("frequency", "freq"):
+                    result.freq = data_list
 
         return result
 
-    def tran_async(self, *args, throttle_interval: float = 0.1) -> 'queue.Queue':
+    def tran_async(self, *args, throttle_interval: float = 0.1) -> "queue.Queue[dict]":
         self._async_throttle_interval = throttle_interval
         self._last_callback_time = 0.0
         self._data_points_sent = 0
@@ -513,11 +538,11 @@ class _FFIBackend:
             try:
                 tstop_str = str(args[1])
                 # Convert units (u = micro, n = nano, m = milli, etc.)
-                if tstop_str.endswith('u'):
+                if tstop_str.endswith("u"):
                     self._sim_tstop = float(tstop_str[:-1]) * 1e-6
-                elif tstop_str.endswith('n'):
+                elif tstop_str.endswith("n"):
                     self._sim_tstop = float(tstop_str[:-1]) * 1e-9
-                elif tstop_str.endswith('m'):
+                elif tstop_str.endswith("m"):
                     self._sim_tstop = float(tstop_str[:-1]) * 1e-3
                 else:
                     self._sim_tstop = float(tstop_str)
@@ -532,7 +557,7 @@ class _FFIBackend:
                 break
 
         # Start background simulation using bg_tran
-        cmd_args = ' '.join(str(arg) for arg in args)
+        cmd_args = " ".join(str(arg) for arg in args)
         self.command(f"bg_tran {cmd_args}")
 
         # Wait for simulation to start or complete (handles fast simulations)
@@ -541,6 +566,7 @@ class _FFIBackend:
 
         # Use race condition approach instead of polling
         import concurrent.futures
+
         with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
 
             def check_running_status():
@@ -558,8 +584,7 @@ class _FFIBackend:
 
                 try:
                     done_futures = concurrent.futures.as_completed(
-                        [status_future, queue_future],
-                        timeout=0.05
+                        [status_future, queue_future], timeout=0.05
                     )
 
                     for future in done_futures:
@@ -589,18 +614,24 @@ class _FFIBackend:
         # Start a thread to handle data retrieval fallback for complex simulations
         # Some complex models (like SKY130) don't trigger data callbacks during bg_tran
         import threading
+
         def data_fallback_handler():
             """Handle data retrieval when callbacks don't work (e.g.,Complex models like SKY130 with savecurrents option)"""
             # Wait for simulation to complete using race condition approach
             import concurrent.futures
-            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as fallback_executor:
+
+            with concurrent.futures.ThreadPoolExecutor(
+                max_workers=1
+            ) as fallback_executor:
 
                 def check_completion_status():
                     """Check if simulation has completed"""
                     return not self._is_running
 
                 while True:
-                    completion_future = fallback_executor.submit(check_completion_status)
+                    completion_future = fallback_executor.submit(
+                        check_completion_status
+                    )
                     try:
                         if completion_future.result(timeout=0.05):
                             break
@@ -618,7 +649,7 @@ class _FFIBackend:
                 try:
                     # Get current vectors from ngspice
                     vector_names = self._get_all_vectors()
-                    if vector_names and 'time' in vector_names:
+                    if vector_names and "time" in vector_names:
                         # Extract actual vector data using _get_vector_info
                         vector_data_map = {}
                         num_points = 0
@@ -627,12 +658,17 @@ class _FFIBackend:
                             vec_info = self._get_vector_info(vec_name)
                             if vec_info and vec_info.v_length > 0:
                                 num_points = max(num_points, vec_info.v_length)
-                                data_list = [vec_info.v_realdata[i] for i in range(vec_info.v_length)]
+                                data_list = [
+                                    vec_info.v_realdata[i]
+                                    for i in range(vec_info.v_length)
+                                ]
                                 vector_data_map[vec_name] = data_list
 
-                        if num_points > 0 and 'time' in vector_data_map:
+                        if num_points > 0 and "time" in vector_data_map:
                             # Sample every 10th point to avoid overwhelming the queue
-                            sample_indices = range(0, num_points, max(1, num_points // 100))
+                            sample_indices = range(
+                                0, num_points, max(1, num_points // 100)
+                            )
 
                             for i in sample_indices:
                                 data_points = {}
@@ -641,21 +677,27 @@ class _FFIBackend:
                                         data_points[name] = values[i]
 
                                 if data_points:
-                                    self._async_data_queue.put_nowait({
-                                        'timestamp': time.time(),
-                                        'data': data_points,
-                                        'index': i
-                                    })
+                                    self._async_data_queue.put_nowait(
+                                        {
+                                            "timestamp": time.time(),
+                                            "data": data_points,
+                                            "index": i,
+                                        }
+                                    )
 
                             if self.debug:
-                                print(f"[ngspice-ffi] Fallback retrieved {len(sample_indices)} data points from {num_points} total points")
+                                print(
+                                    f"[ngspice-ffi] Fallback retrieved {len(sample_indices)} data points from {num_points} total points"
+                                )
 
                 except Exception as e:
                     # Fallback failed, but don't crash - log errors for diagnostics
                     import logging
+
                     logging.error("Exception in data_fallback_handler: %s", e)
                     if self.debug:
                         import traceback
+
                         logging.debug("Fallback traceback: %s", traceback.format_exc())
 
         fallback_thread = threading.Thread(target=data_fallback_handler, daemon=True)
@@ -664,74 +706,77 @@ class _FFIBackend:
         # Return the queue for direct access
         return self._async_data_queue
 
-    def op_async(self, callback: Optional[Callable] = None) -> Generator:
-       self._async_callback = callback
-       while not self._async_data_queue.empty():
-           try:
-               self._async_data_queue.get_nowait()
-           except queue.Empty:
-               break
+    def op_async(
+        self, callback: Optional[Callable[[dict], None]] = None
+    ) -> Generator[dict, None, None]:
+        self._async_callback = callback
+        while not self._async_data_queue.empty():
+            try:
+                self._async_data_queue.get_nowait()
+            except queue.Empty:
+                break
 
-       # Start background simulation - set up analysis first, then run
-       self.command("op")
-       self.command("bg_run")
+        # Start background simulation - set up analysis first, then run
+        self.command("op")
+        self.command("bg_run")
 
-       # Wait for simulation to start using race condition approach
-       timeout = time.time() + 5.0
+        # Wait for simulation to start using race condition approach
+        timeout = time.time() + 5.0
 
-       import concurrent.futures
-       startup_detected = False
-       with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        import concurrent.futures
 
-           def check_op_startup():
-               """Check if OP analysis has started"""
-               return self._is_running
+        startup_detected = False
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
 
-           while time.time() < timeout:
-               startup_future = executor.submit(check_op_startup)
-               try:
-                   if startup_future.result(timeout=0.05):
-                       startup_detected = True
-                       break
-               except concurrent.futures.TimeoutError:
-                   pass
-               finally:
-                   if not startup_future.done():
-                       startup_future.cancel()
+            def check_op_startup():
+                """Check if OP analysis has started"""
+                return self._is_running
 
-       if not startup_detected:
-           raise NgspiceError("Background operating point analysis failed to start")
+            while time.time() < timeout:
+                startup_future = executor.submit(check_op_startup)
+                try:
+                    if startup_future.result(timeout=0.05):
+                        startup_detected = True
+                        break
+                except concurrent.futures.TimeoutError:
+                    pass
+                finally:
+                    if not startup_future.done():
+                        startup_future.cancel()
 
-       # Stream data as it becomes available
-       while self._is_running:
-           try:
-               data_point = self._async_data_queue.get(timeout=0.1)
-               if callback:
-                   callback(data_point)
+        if not startup_detected:
+            raise NgspiceError("Background operating point analysis failed to start")
 
-               yield data_point
+        # Stream data as it becomes available
+        while self._is_running:
+            try:
+                data_point = self._async_data_queue.get(timeout=0.1)
+                if callback:
+                    callback(data_point)
 
-           except queue.Empty:
-               # Check if simulation is still running
-               if hasattr(self.lib, 'ngSpice_running'):
-                   if not self.lib.ngSpice_running():
-                       self._is_running = False
-                       break
+                yield data_point
 
-       # Drain any remaining data
-       while not self._async_data_queue.empty():
-           try:
-               data_point = self._async_data_queue.get_nowait()
-               if callback:
-                   callback(data_point)
-               yield data_point
-           except queue.Empty:
-               break
+            except queue.Empty:
+                # Check if simulation is still running
+                if hasattr(self.lib, "ngSpice_running"):
+                    if not self.lib.ngSpice_running():
+                        self._is_running = False
+                        break
+
+        # Drain any remaining data
+        while not self._async_data_queue.empty():
+            try:
+                data_point = self._async_data_queue.get_nowait()
+                if callback:
+                    callback(data_point)
+                yield data_point
+            except queue.Empty:
+                break
 
     def is_running(self) -> bool:
         return self._is_running
 
-    def get_async_data_queue(self) -> 'queue.Queue':
+    def get_async_data_queue(self) -> "queue.Queue[dict]":
         """Get direct access to the async data queue"""
         return self._async_data_queue
 
@@ -743,6 +788,7 @@ class _FFIBackend:
             timeout = time.time() + 2.0
 
             import concurrent.futures
+
             with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
 
                 def check_stop_status():
@@ -767,7 +813,9 @@ class _FFIBackend:
             # Already stopped
             return True
 
-    def safe_halt_simulation(self, max_attempts: int = 3, wait_time: float = 0.2) -> bool:
+    def safe_halt_simulation(
+        self, max_attempts: int = 3, wait_time: float = 0.2
+    ) -> bool:
         """Halt async simulation safely."""
         if not self._is_running:
             return True
@@ -786,10 +834,14 @@ class _FFIBackend:
 
     def halt_simulation(self, timeout: float = 2.0) -> bool:
         """Halt async simulation (alias for safe_halt_simulation for API compatibility)."""
-        result = self.safe_halt_simulation(max_attempts=int(timeout / 0.2), wait_time=0.2)
+        result = self.safe_halt_simulation(
+            max_attempts=int(timeout / 0.2), wait_time=0.2
+        )
         return result
 
-    def safe_resume_simulation(self, max_attempts: int = 3, wait_time: float = 2.0) -> bool:
+    def safe_resume_simulation(
+        self, max_attempts: int = 3, wait_time: float = 2.0
+    ) -> bool:
         """Resume a halted simulation safely."""
         if self._is_running:
             return True  # Already running
@@ -800,6 +852,7 @@ class _FFIBackend:
 
             # Check if ngspice is actually running using the library function
             import concurrent.futures
+
             with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
 
                 def check_resume_status():
@@ -840,6 +893,7 @@ class _FFIBackend:
 
         # Check if ngspice is actually running using the library function
         import concurrent.futures
+
         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
 
             def check_resume_status():
@@ -876,35 +930,64 @@ class _FFIBackend:
         vectors = []
         i = 0
         while vecs_ptr and vecs_ptr[i]:
-            vectors.append(vecs_ptr[i].decode('utf-8'))
+            vectors.append(vecs_ptr[i].decode("utf-8"))
             i += 1
         return vectors
 
     def _get_vector_info(self, vector_name: str) -> Optional[VectorInfo]:
-        vec_info_ptr = self.lib.ngGet_Vec_Info(vector_name.encode('utf-8'))
+        vec_info_ptr = self.lib.ngGet_Vec_Info(vector_name.encode("utf-8"))
         return vec_info_ptr.contents if vec_info_ptr else None
 
     @staticmethod
     def find_library() -> ctypes.CDLL:
-        if sys.platform == 'win32':
-            return ctypes.CDLL('libngspice-0.dll')
-        elif sys.platform == 'darwin':
-            return ctypes.CDLL('libngspice.0.dylib')
+        if sys.platform == "win32":
+            return ctypes.CDLL("libngspice-0.dll")
+        elif sys.platform == "darwin":
+            return ctypes.CDLL("libngspice.0.dylib")
         else:
-            return ctypes.CDLL('libngspice.so.0')
+            return ctypes.CDLL("libngspice.so.0")
 
     def _setup_library_functions(self):
         # Define callback function prototypes
-        self._SendChar = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_char_p, ctypes.c_int, ctypes.c_void_p)
-        self._SendStat = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_char_p, ctypes.c_int, ctypes.c_void_p)
-        self._ControlledExit = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_int, ctypes.c_bool, ctypes.c_bool, ctypes.c_int, ctypes.c_void_p)
-        self._SendData = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.POINTER(self.VecValuesAll), ctypes.c_int, ctypes.c_int, ctypes.c_void_p)
-        self._SendInitData = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.POINTER(self.VecInfoAll), ctypes.c_int, ctypes.c_void_p)
-        self._BGThreadRunning = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_bool, ctypes.c_int, ctypes.c_void_p)
+        self._SendChar = ctypes.CFUNCTYPE(
+            ctypes.c_int, ctypes.c_char_p, ctypes.c_int, ctypes.c_void_p
+        )
+        self._SendStat = ctypes.CFUNCTYPE(
+            ctypes.c_int, ctypes.c_char_p, ctypes.c_int, ctypes.c_void_p
+        )
+        self._ControlledExit = ctypes.CFUNCTYPE(
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_bool,
+            ctypes.c_bool,
+            ctypes.c_int,
+            ctypes.c_void_p,
+        )
+        self._SendData = ctypes.CFUNCTYPE(
+            ctypes.c_int,
+            ctypes.POINTER(self.VecValuesAll),
+            ctypes.c_int,
+            ctypes.c_int,
+            ctypes.c_void_p,
+        )
+        self._SendInitData = ctypes.CFUNCTYPE(
+            ctypes.c_int, ctypes.POINTER(self.VecInfoAll), ctypes.c_int, ctypes.c_void_p
+        )
+        self._BGThreadRunning = ctypes.CFUNCTYPE(
+            ctypes.c_int, ctypes.c_bool, ctypes.c_int, ctypes.c_void_p
+        )
 
         # Core functions
         self.lib.ngSpice_Init.restype = ctypes.c_int
-        self.lib.ngSpice_Init.argtypes = [self._SendChar, self._SendStat, self._ControlledExit, self._SendData, self._SendInitData, self._BGThreadRunning, ctypes.c_void_p]
+        self.lib.ngSpice_Init.argtypes = [
+            self._SendChar,
+            self._SendStat,
+            self._ControlledExit,
+            self._SendData,
+            self._SendInitData,
+            self._BGThreadRunning,
+            ctypes.c_void_p,
+        ]
 
         self.lib.ngSpice_Command.restype = ctypes.c_int
         self.lib.ngSpice_Command.argtypes = [ctypes.c_char_p]

--- a/ordec/sim2/ngspice_mp.py
+++ b/ordec/sim2/ngspice_mp.py
@@ -23,9 +23,9 @@ except (RuntimeError, AttributeError):
 
 class FFIWorkerProcess:
     """
-    This worker runs in a separate process. It creates a standard _FFIBackend
-    and acts as a bridge, forwarding commands and results between the main
-    process and the FFI backend.
+    This worker runs in a separate process. It creates an FFI backend
+    instance and acts as a bridge, forwarding commands and results between the
+    worker process and the FFI backend implementation.
     """
     #TODO performance
 
@@ -92,7 +92,7 @@ class FFIWorkerProcess:
 
     def run(self):
         """Main worker loop. Waits for commands and dispatches them."""
-        from .ngspice_ffi import _FFIBackend
+        from .ngspice_ffi import NgspiceFFI
         import traceback  # Ensure traceback is available in worker process
 
         # Initialize thread synchronization objects (can't pickle these)
@@ -105,7 +105,7 @@ class FFIWorkerProcess:
         msg = self.conn.recv()
         if msg['type'] == 'init':
             try:
-                self.backend = _FFIBackend(debug=msg.get('debug', False))
+                self.backend = NgspiceFFI(debug=msg.get('debug', False))
                 self.conn.send({'type': 'init_success'})
             except Exception as e:
                 self.conn.send({'type': 'error', 'data': pickle.dumps(e), 'traceback': traceback.format_exc()})
@@ -303,7 +303,7 @@ class FFIWorkerProcess:
         self._relay_thread = threading.Thread(target=relay_data, daemon=True)
         self._relay_thread.start()
 
-class IsolatedFFIBackend:
+class NgspiceIsolatedFFI:
     """
     A proxy that runs FFI calls in an isolated child process.
     """
@@ -318,15 +318,14 @@ class IsolatedFFIBackend:
         p = Process(target=worker.run)
         p.start()
 
-        backend = None
+        backend = NgspiceIsolatedFFI(parent_conn, p, async_queue)
         try:
-            backend = IsolatedFFIBackend(parent_conn, p, async_queue)
             parent_conn.send({'type': 'init', 'debug': debug})
             response = parent_conn.recv()
             if response['type'] == 'error':
-                 exc = pickle.loads(response['data'])
-                 exc.args += (f"\n--- Traceback from worker process ---\n{response['traceback']}",)
-                 raise exc
+                exc = pickle.loads(response['data'])
+                exc.args += (f"\n--- Traceback from worker process ---\n{response['traceback']}",)
+                raise exc
             yield backend
         finally:
             if backend:

--- a/ordec/sim2/ngspice_mp.py
+++ b/ordec/sim2/ngspice_mp.py
@@ -477,8 +477,8 @@ class IsolatedFFIBackend:
     def reset(self): return self._call_worker('reset')
     def cleanup(self): pass
 
-    def _create_async_generator(self, cmd, *args, **kwargs):
-        callback = kwargs.pop('callback', None)
+    def _create_async_generator(self, cmd, *args, callback=None, **kwargs):
+        # callback is now an explicit parameter and must NOT be forwarded to the worker
         self._call_worker(cmd, *args, **kwargs)
 
         def generator_with_callback():

--- a/ordec/sim2/ngspice_mp.py
+++ b/ordec/sim2/ngspice_mp.py
@@ -492,8 +492,16 @@ class IsolatedFFIBackend:
 
         return generator_with_callback()
 
-    def tran_async(self, *args, throttle_interval: float = 0.1):
-        self._call_worker('tran_async', *args, throttle_interval=throttle_interval)
+    def tran_async(self, tstep, tstop=None, *extra_args, throttle_interval: float = 0.1):
+        """
+        Start asynchronous transient simulation (explicit signature).
+
+        New strict signature: explicit `tstep`, optional `tstop`, plus any
+        extra ngspice tran args forwarded via `extra_args`. The throttle
+        interval is forwarded as a keyword for the worker.
+        """
+        # Forward explicit args to the worker
+        self._call_worker('tran_async', tstep, tstop, *extra_args, throttle_interval=throttle_interval)
         return self.async_queue
 
     def safe_halt_simulation(self, max_attempts: int = 3, wait_time: float = 1.0):
@@ -579,9 +587,15 @@ class IsolatedFFIBackend:
 
         return False
 
-    def tran_async(self, *args, **kwargs):
+    def tran_async(self, tstep, tstop=None, *extra_args, **kwargs):
+        """
+        Mark async simulation running and forward explicit tran arguments to worker.
+
+        Accepts the explicit (tstep, tstop) signature to match updated backends.
+        Any additional keyword arguments are forwarded to the worker.
+        """
         self._async_simulation_running = True
-        self._call_worker('tran_async', *args, **kwargs)
+        self._call_worker('tran_async', tstep, tstop, *extra_args, **kwargs)
         return self.async_queue
 
     def op_async(self, *args, **kwargs):

--- a/ordec/sim2/ngspice_subprocess.py
+++ b/ordec/sim2/ngspice_subprocess.py
@@ -525,6 +525,7 @@ class _SubprocessBackend:
                                         data_point = {
                                             "timestamp": time.time(),
                                             "data": {"time": time_val},
+                                            "signal_kinds": {"time": SignalKind.TIME},
                                             "index": self._data_points_sent,
                                             "progress": min(1.0, time_val / tstop)
                                             if tstop > 0
@@ -543,6 +544,26 @@ class _SubprocessBackend:
                                                     data_point["data"][header] = float(
                                                         row_data[i]
                                                     )
+                                                    # Determine signal kind for this header
+                                                    if header.lower() == "time":
+                                                        data_point["signal_kinds"][
+                                                            header
+                                                        ] = SignalKind.TIME
+                                                    elif (
+                                                        header.startswith("@")
+                                                        and "[" in header
+                                                    ):
+                                                        data_point["signal_kinds"][
+                                                            header
+                                                        ] = SignalKind.CURRENT
+                                                    elif header.endswith("#branch"):
+                                                        data_point["signal_kinds"][
+                                                            header
+                                                        ] = SignalKind.CURRENT
+                                                    else:
+                                                        data_point["signal_kinds"][
+                                                            header
+                                                        ] = SignalKind.VOLTAGE
                                                 except ValueError:
                                                     pass  # Skip non-numeric values
 
@@ -555,6 +576,10 @@ class _SubprocessBackend:
                                                     data_point["data"][node_name] = (
                                                         voltage_val
                                                     )
+                                                    # Add signal kind for voltage data
+                                                    data_point["signal_kinds"][
+                                                        node_name
+                                                    ] = SignalKind.VOLTAGE
 
                                         # Debug: print data point structure
                                         if (

--- a/ordec/sim2/sim_hierarchy.py
+++ b/ordec/sim2/sim_hierarchy.py
@@ -1,18 +1,32 @@
 # SPDX-FileCopyrightText: 2025 ORDeC contributors
 # SPDX-License-Identifier: Apache-2.0
+"""
+High-level simulation helpers.
+
+This module provides:
+- helpers to build a simulation hierarchy from a schematic/symbol tree
+- a module-level `AlterSession` class that can be used to alter component
+  parameters and run analyses while keeping an ngspice session alive
+- `HighlevelSim` which exposes convenient methods to run op/tran/ac and
+  to export transient results to VCD with flexible timescale handling.
+"""
 
 from typing import Optional
 from contextlib import contextmanager
+import re
+import time
 
 from ..core import *
 from ..core.schema import SimType
 from .ngspice import Ngspice, Netlister
+
 
 def build_hier_symbol(simhier, symbol):
     simhier.schematic = symbol
     for pin in symbol.all(Pin):
         # TODO: implement hierarchical construction within schematic
         setattr(simhier, pin.full_path_str(), SimNet(eref=pin))
+
 
 def build_hier_schematic(simhier, schematic):
     simhier.schematic = schematic
@@ -31,8 +45,92 @@ def build_hier_schematic(simhier, schematic):
         else:
             build_hier_schematic(subnode, subschematic)
 
+
+class AlterSession:
+    """Module-level AlterSession used by `HighlevelSim.alter_session`.
+
+    This keeps a reference to the active high-level sim and the ngspice session
+    and exposes helpers for altering components, running analyses and controlling
+    asynchronous transient runs.
+    """
+
+    def __init__(self, highlevel_sim, ngspice_sim):
+        self.highlevel_sim = highlevel_sim
+        self.ngspice_sim = ngspice_sim
+        # mark active simulation on the high-level object
+        highlevel_sim._active_sim = ngspice_sim
+        # preload the netlist so subsequent commands refer to the correct circuit
+        ngspice_sim.load_netlist(highlevel_sim.netlister.out())
+
+    def alter_component(self, component_instance, **parameters):
+        """Alter component parameters using a SimInstance or SchemInstance."""
+        # Accept either a SimInstance (has .eref) or a SchemInstance (find mapping)
+        if not hasattr(component_instance, "eref"):
+            sim_instance = self.highlevel_sim.find_sim_instance_from_schem_instance(component_instance)
+            if not sim_instance:
+                raise ValueError(f"Could not find simulation instance for component {component_instance!r}")
+            component_instance = sim_instance
+
+        netlist_name = self.highlevel_sim.get_component_netlist_name(component_instance)
+        for param_name, param_value in parameters.items():
+            alter_cmd = f"alter {netlist_name} {param_name}={param_value}"
+            self.ngspice_sim.command(alter_cmd)
+        return True
+
+    def show_component(self, component_instance):
+        """Return backend response to `show <component>` for given instance."""
+        if not hasattr(component_instance, "eref"):
+            sim_instance = self.highlevel_sim.find_sim_instance_from_schem_instance(component_instance)
+            if not sim_instance:
+                raise ValueError(f"Could not find simulation instance for component {component_instance!r}")
+            component_instance = sim_instance
+
+        netlist_name = self.highlevel_sim.get_component_netlist_name(component_instance)
+        return self.ngspice_sim.command(f"show {netlist_name}")
+
+    def op(self):
+        """Run operating-point analysis and update the simulation hierarchy."""
+        self.highlevel_sim.simhier.sim_type = SimType.DC
+        for hook in self.highlevel_sim.sim_setup_hooks:
+            hook(self.ngspice_sim)
+
+        for vtype, name, subname, value in self.ngspice_sim.op():
+            if vtype == "voltage":
+                try:
+                    simnet = self.highlevel_sim.str_to_simobj[name]
+                    simnet.dc_voltage = value
+                except KeyError:
+                    # ignore internal nodes we can't map
+                    continue
+            elif vtype == "current":
+                if subname not in ("id", "branch", "i"):
+                    continue
+                try:
+                    siminstance = self.highlevel_sim.str_to_simobj[name]
+                    siminstance.dc_current = value
+                except KeyError:
+                    continue
+
+    def start_async_tran(self, tstep, tstop, **kwargs):
+        """Start an asynchronous transient simulation (backend-specific)."""
+        return self.ngspice_sim.tran_async(tstep, tstop, **kwargs)
+
+    def halt_simulation(self, timeout=1.0):
+        if hasattr(self.ngspice_sim, "safe_halt_simulation"):
+            return self.ngspice_sim.safe_halt_simulation(wait_time=timeout)
+        raise NotImplementedError(f"Backend {type(self.ngspice_sim).__name__} does not support safe_halt_simulation")
+
+    def resume_simulation(self, timeout=2.0):
+        if hasattr(self.ngspice_sim, "safe_resume_simulation"):
+            return self.ngspice_sim.safe_resume_simulation(wait_time=timeout)
+        raise NotImplementedError(f"Backend {type(self.ngspice_sim).__name__} does not support safe_resume_simulation")
+
+    def is_running(self):
+        return self.ngspice_sim.is_running()
+
+
 class HighlevelSim:
-    def __init__(self, top: Schematic, simhier: SimHierarchy, enable_savecurrents: bool = True, backend: str = 'subprocess'):
+    def __init__(self, top: Schematic, simhier: SimHierarchy, enable_savecurrents: bool = True, backend: str = "subprocess"):
         self.top = top
         self.backend = backend
 
@@ -40,8 +138,10 @@ class HighlevelSim:
         self.netlister.netlist_hier(self.top)
 
         self.simhier = simhier
-        #self.simhier.schematic = self.top
+        # build hierarchical simulation nodes
         build_hier_schematic(self.simhier, self.top)
+
+        # map netlister names to sim objects for quick lookup
         self.str_to_simobj = {}
         for sn in simhier.all(SimNet):
             name = self.netlister.name_hier_simobj(sn)
@@ -51,9 +151,9 @@ class HighlevelSim:
             name = self.netlister.name_hier_simobj(sn)
             self.str_to_simobj[name] = sn
 
-        # Collect simulation setup hooks from netlister
+        # Collect simulation setup hooks from netlister if present
         self.sim_setup_hooks = []
-        if hasattr(self.netlister, '_sim_setup_hooks'):
+        if hasattr(self.netlister, "_sim_setup_hooks"):
             self.sim_setup_hooks = list(self.netlister._sim_setup_hooks)
 
         self._active_sim = None
@@ -61,35 +161,30 @@ class HighlevelSim:
     def op(self):
         self.simhier.sim_type = SimType.DC
         with Ngspice.launch(debug=False, backend=self.backend) as sim:
-            # Run simulation setup hooks
             for hook in self.sim_setup_hooks:
                 hook(sim)
 
             sim.load_netlist(self.netlister.out())
             for vtype, name, subname, value in sim.op():
-                if vtype == 'voltage':
+                if vtype == "voltage":
                     try:
                         simnet = self.str_to_simobj[name]
                         simnet.dc_voltage = value
                     except KeyError:
-                        # Silently ignore internal subcircuit voltages that can't be mapped to hierarchy
-                        # These are typically internal nodes within subcircuits (e.g. device body nodes)
+                        # ignore internal nodes we don't map
                         continue
-                elif vtype == 'current':
-                    if subname not in ('id', 'branch', 'i'):
+                elif vtype == "current":
+                    if subname not in ("id", "branch", "i"):
                         continue
                     try:
                         siminstance = self.str_to_simobj[name]
                         siminstance.dc_current = value
                     except KeyError:
-                        # Silently ignore internal subcircuit device currents that can't be mapped to hierarchy
-                        # These are typically internal devices within subcircuits (e.g. MOSFET models)
                         continue
 
     def tran(self, tstep, tstop):
         self.simhier.sim_type = SimType.TRAN
         with Ngspice.launch(debug=False, backend=self.backend) as sim:
-            # Run simulation setup hooks
             for hook in self.sim_setup_hooks:
                 hook(sim)
 
@@ -121,41 +216,91 @@ class HighlevelSim:
             for name, value in data.voltages.items():
                 try:
                     simnet = self.str_to_simobj[name]
-                    simnet.ac_voltage = tuple([(c.real, c.imag) for c in value])
+                    simnet.ac_voltage = tuple((c.real, c.imag) for c in value)
                 except KeyError:
                     continue
 
             for name, currents in data.currents.items():
                 try:
                     siminstance = self.str_to_simobj[name]
-                    if 'id' in currents:
-                        main_current = currents['id']
-                    elif 'branch' in currents:
-                        main_current = currents['branch']
+                    if "id" in currents:
+                        main_current = currents["id"]
+                    elif "branch" in currents:
+                        main_current = currents["branch"]
                     elif currents:
                         main_current = next(iter(currents.values()))
                     else:
-                        continue # No currents available for this instance
-
-                    siminstance.ac_current = tuple([(c.real, c.imag) for c in main_current])
+                        continue
+                    siminstance.ac_current = tuple((c.real, c.imag) for c in main_current)
                 except (KeyError, StopIteration):
                     continue
 
-    def export_to_vcd(self, filename="simulation.vcd", signal_names=None, timescale="1us"):
-        import time
+    def _parse_timescale_factor(self, timescale: str) -> float:
+        """Parse a VCD timescale string like '1us', '10 ns' or '1 s'.
 
+        Returns the factor to multiply seconds by to obtain integer units used
+        in VCD timestamps. Example: timescale='1us' -> returns 1e6.
+
+        The format accepted is: <number><unit> where unit is one of
+        s, ms, us, ns, ps, fs (case-insensitive) and optional whitespace.
+        """
+        if not isinstance(timescale, str) or not timescale.strip():
+            raise ValueError("timescale must be a non-empty string like '1us' or '10 ns'")
+
+        m = re.match(r"^\s*([0-9]+(?:\.[0-9]+)?)\s*([a-zA-Z]+)\s*$", timescale)
+        if not m:
+            raise ValueError(f"Invalid timescale format: '{timescale}'")
+
+        value_str, unit = m.group(1), m.group(2).lower()
+        try:
+            value = float(value_str)
+        except ValueError:
+            raise ValueError(f"Invalid numeric value in timescale: '{value_str}'")
+
+        unit_map = {
+            "s": 1.0,
+            "ms": 1e-3,
+            "us": 1e-6,
+            "ns": 1e-9,
+            "ps": 1e-12,
+            "fs": 1e-15,
+        }
+
+        if unit not in unit_map:
+            raise ValueError(f"Unsupported timescale unit: '{unit}'. Supported: {', '.join(unit_map.keys())}")
+
+        # timescale_seconds is the number of seconds per timescale tick (e.g. 1us -> 1e-6)
+        timescale_seconds = value * unit_map[unit]
+        if timescale_seconds <= 0:
+            raise ValueError("Timescale must be greater than zero")
+
+        # factor to convert seconds to timescale units (e.g. 1 second -> 1e6 microseconds)
+        return 1.0 / timescale_seconds
+
+    def export_to_vcd(self, filename="simulation.vcd", signal_names=None, timescale="1us"):
+        """Export transient results to a VCD file.
+
+        - `signal_names` can be an iterable of base signal names to filter exports.
+        - `timescale` is a string like '1us' or '10ns' controlling the VCD timescale.
+        """
         if self.simhier.sim_type is None:
             raise ValueError("No simulation results available. Run a simulation first.")
 
         if self.simhier.sim_type != SimType.TRAN:
             raise ValueError(f"VCD export only supported for transient simulations. Current simulation type: {self.simhier.sim_type}")
 
-        if not hasattr(self.simhier, 'time') or not self.simhier.time:
+        if not hasattr(self.simhier, "time") or not self.simhier.time:
             raise ValueError("No time data available for VCD export")
 
+        # determine conversion factor from seconds to requested units
         try:
-            with open(filename, 'w') as vcd_file:
-                # VCD header
+            time_to_units = self._parse_timescale_factor(timescale)
+        except ValueError as e:
+            raise ValueError(f"Invalid timescale: {e}")
+
+        try:
+            with open(filename, "w") as vcd_file:
+                # Header
                 vcd_file.write("$date\n")
                 vcd_file.write(f"   {time.strftime('%Y-%m-%d %H:%M:%S')}\n")
                 vcd_file.write("$end\n")
@@ -164,50 +309,51 @@ class HighlevelSim:
                 vcd_file.write("$end\n")
                 vcd_file.write(f"$timescale {timescale} $end\n")
 
-                # Collect signals to export
+                # Collect signals with transient voltage data
                 signals_to_export = []
-                signal_chars = "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"  # VCD variable characters
+                # limited set of single-char VCD identifiers
+                signal_chars = "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
 
                 for i, simnet in enumerate(self.simhier.all(SimNet)):
-                    signal_name = simnet.full_path_str().split('.')[-1]  # Get base name
+                    base_name = simnet.full_path_str().split(".")[-1]
 
-                    # Filter by signal_names if provided
-                    if signal_names is not None and signal_name not in signal_names:
+                    if signal_names is not None and base_name not in signal_names:
                         continue
 
-                    if hasattr(simnet, 'trans_voltage') and simnet.trans_voltage is not None:
+                    if hasattr(simnet, "trans_voltage") and simnet.trans_voltage is not None:
                         if i < len(signal_chars):
-                            char = signal_chars[i]
-                            signals_to_export.append((signal_name, char, simnet.trans_voltage))
+                            ident = signal_chars[i]
                         else:
-                            # Fallback for many signals - use extended character set
-                            char = f"signal{i}"
-                            signals_to_export.append((signal_name, char, simnet.trans_voltage))
+                            # multi-character identifier for many signals; VCD allows this
+                            ident = f"sig{i}"
+                        signals_to_export.append((base_name, ident, simnet.trans_voltage))
 
                 if not signals_to_export:
                     raise ValueError("No signals with transient voltage data found for VCD export")
 
-                # Variable definitions
+                # Definitions
                 vcd_file.write("$scope module top $end\n")
-                for signal_name, char, _ in signals_to_export:
-                    vcd_file.write(f"$var real 64 {char} {signal_name} $end\n")
+                for name, ident, _ in signals_to_export:
+                    vcd_file.write(f"$var real 64 {ident} {name} $end\n")
                 vcd_file.write("$upscope $end\n")
                 vcd_file.write("$enddefinitions $end\n")
 
                 # Initial values at time 0
                 vcd_file.write("#0\n")
-                for signal_name, char, voltage_data in signals_to_export:
+                for _, ident, voltage_data in signals_to_export:
                     if voltage_data and len(voltage_data) > 0:
-                        vcd_file.write(f"r{voltage_data[0]} {char}\n")
+                        # Represent real value with default float formatting
+                        vcd_file.write(f"r{voltage_data[0]} {ident}\n")
 
-                # Value changes at each time point
+                # Value changes at each time point, converted to requested timescale
                 time_data = self.simhier.time
                 for time_idx in range(1, len(time_data)):
-                    time_units = int(time_data[time_idx] * 1e6)  # Convert to microseconds
+                    # convert seconds -> requested timescale integer units
+                    time_units = int(time_data[time_idx] * time_to_units)
                     vcd_file.write(f"#{time_units}\n")
-                    for signal_name, char, voltage_data in signals_to_export:
+                    for _, ident, voltage_data in signals_to_export:
                         if len(voltage_data) > time_idx:
-                            vcd_file.write(f"r{voltage_data[time_idx]} {char}\n")
+                            vcd_file.write(f"r{voltage_data[time_idx]} {ident}\n")
 
             return True
 
@@ -221,97 +367,27 @@ class HighlevelSim:
     def find_component_by_ref_name(self, ref_name):
         """Find a component instance by its reference name (e.g., 'r1', 'c1')."""
         for sim_instance in self.simhier.all(SimInstance):
-            if hasattr(sim_instance, 'eref') and hasattr(sim_instance.eref, 'full_path_str') and sim_instance.eref.full_path_str().endswith(ref_name):
+            if hasattr(sim_instance, "eref") and hasattr(sim_instance.eref, "full_path_str") and sim_instance.eref.full_path_str().endswith(ref_name):
                 return sim_instance
-
         return None
 
     def find_sim_instance_from_schem_instance(self, schem_instance):
         """Find a SimInstance that corresponds to a SchemInstance from the schematic."""
         for sim_instance in self.simhier.all(SimInstance):
-            if hasattr(sim_instance, 'eref') and sim_instance.eref == schem_instance:
+            if hasattr(sim_instance, "eref") and sim_instance.eref == schem_instance:
                 return sim_instance
         return None
 
     @contextmanager
     def alter_session(self, backend=None, debug=False):
-        """Context manager for alter operations that maintains ngspice session."""
+        """Context manager that yields an `AlterSession` bound to an ngspice session.
+
+        Example:
+            with highlevel.alter_session() as s:
+                s.alter_component(inst, value=10)
+                s.op()
+        """
         use_backend = backend or self.backend
-
-        class AlterSession:
-            def __init__(self, highlevel_sim, ngspice_sim):
-                self.highlevel_sim = highlevel_sim
-                self.ngspice_sim = ngspice_sim
-                highlevel_sim._active_sim = ngspice_sim
-                ngspice_sim.load_netlist(highlevel_sim.netlister.out())
-
-            def alter_component(self, component_instance, **parameters):
-                """Alter component parameters using component instance."""
-                # If we get a SchemInstance, find the corresponding SimInstance
-                if not hasattr(component_instance, 'eref'):
-                    sim_instance = self.highlevel_sim.find_sim_instance_from_schem_instance(component_instance)
-                    if not sim_instance:
-                        raise ValueError(f"Could not find simulation instance for component {component_instance}")
-                    component_instance = sim_instance
-
-                netlist_name = self.highlevel_sim.get_component_netlist_name(component_instance)
-                for param_name, param_value in parameters.items():
-                    alter_cmd = f"alter {netlist_name} {param_name}={param_value}"
-                    self.ngspice_sim.command(alter_cmd)
-                return True
-
-            def show_component(self, component_instance):
-                """Show component parameters using component instance."""
-                # If we get a SchemInstance, find the corresponding SimInstance
-                if not hasattr(component_instance, 'eref'):
-                    sim_instance = self.highlevel_sim.find_sim_instance_from_schem_instance(component_instance)
-                    if not sim_instance:
-                        raise ValueError(f"Could not find simulation instance for component {component_instance}")
-                    component_instance = sim_instance
-
-                netlist_name = self.highlevel_sim.get_component_netlist_name(component_instance)
-                return self.ngspice_sim.command(f"show {netlist_name}")
-
-            def op(self):
-                """Run operating point analysis and update hierarchy."""
-                self.highlevel_sim.simhier.sim_type = SimType.DC
-                for hook in self.highlevel_sim.sim_setup_hooks:
-                    hook(self.ngspice_sim)
-                for vtype, name, subname, value in self.ngspice_sim.op():
-                    if vtype == 'voltage':
-                        try:
-                            simnet = self.highlevel_sim.str_to_simobj[name]
-                            simnet.dc_voltage = value
-                        except KeyError:
-                            continue
-                    elif vtype == 'current':
-                        if subname not in ('id', 'branch', 'i'):
-                            continue
-                        try:
-                            siminstance = self.highlevel_sim.str_to_simobj[name]
-                            siminstance.dc_current = value
-                        except KeyError:
-                            continue
-
-            def start_async_tran(self, tstep, tstop, **kwargs):
-                """Start async transient simulation."""
-                return self.ngspice_sim.tran_async(tstep, tstop, **kwargs)
-
-            def halt_simulation(self, timeout=1.0):
-                if hasattr(self.ngspice_sim, 'safe_halt_simulation'):
-                    return self.ngspice_sim.safe_halt_simulation(wait_time=timeout)
-                else:
-                    raise NotImplementedError(f"Backend {type(self.ngspice_sim).__name__} does not support safe_halt_simulation")
-
-            def resume_simulation(self, timeout=2.0):
-                if hasattr(self.ngspice_sim, 'safe_resume_simulation'):
-                    return self.ngspice_sim.safe_resume_simulation(wait_time=timeout)
-                else:
-                    raise NotImplementedError(f"Backend {type(self.ngspice_sim).__name__} does not support safe_resume_simulation")
-
-            def is_running(self):
-                return self.ngspice_sim.is_running()
-
         with Ngspice.launch(debug=debug, backend=use_backend) as ngspice_sim:
             try:
                 yield AlterSession(self, ngspice_sim)

--- a/tests/test_sim2.py
+++ b/tests/test_sim2.py
@@ -183,7 +183,7 @@ C1 out 0 1uF IC=0
         sim.load_netlist(netlist)
 
         # Start async simulation - returns queue instead of generator
-        data_queue = sim.tran_async("5us", "10ms")
+        data_queue = sim.tran_async("5u", "10m")
         assert isinstance(data_queue, queue.Queue), "tran_async should return Queue object"
 
         # Wait for startup

--- a/tests/test_sim2_async.py
+++ b/tests/test_sim2_async.py
@@ -25,9 +25,9 @@ def test_highlevel_async_tran_basic(backend):
         data_points.append(result)
         time_values.append(result.time)
 
-        # Verify hierarchical access works
+        # Verify hierarchical access works; result.a is a numeric value representing the signal
         assert hasattr(result, 'a')
-        assert hasattr(result.a, 'voltage')
+        assert isinstance(result.a, (int, float))
         assert hasattr(result, 'time')
 
         # Break after collecting enough data
@@ -161,7 +161,7 @@ def test_highlevel_async_mos_sourcefollower(backend):
 
     final_result = data_points[-1]
     assert hasattr(final_result, 'o')
-    assert hasattr(final_result.o, 'voltage')
+    assert isinstance(final_result.o, (int, float))
 
 
 @pytest.mark.libngspice
@@ -180,7 +180,7 @@ def test_highlevel_async_mos_inverter(backend):
 
     final_result = data_points[-1]
     assert hasattr(final_result, 'o')
-    assert hasattr(final_result.o, 'voltage')
+    assert isinstance(final_result.o, (int, float))
 
 
 @pytest.mark.libngspice
@@ -198,7 +198,7 @@ def test_highlevel_async_sky_inverter(backend):
 
     final_result = data_points[-1]
     assert hasattr(final_result, 'o')
-    assert hasattr(final_result.o, 'voltage')
+    assert isinstance(final_result.o, (int, float))
 
 
 @pytest.mark.libngspice
@@ -234,7 +234,7 @@ def test_highlevel_async_multiple_circuits(backend):
 
     assert len(results1) >= 1
     assert hasattr(results1[0], 'a')
-    assert hasattr(results1[0].a, 'voltage')
+    assert isinstance(results1[0].a, (int, float))
 
     # Second circuit
     h2 = lib_test.ResdivHierTb(backend=backend)
@@ -246,7 +246,7 @@ def test_highlevel_async_multiple_circuits(backend):
 
     assert len(results2) >= 1
     assert hasattr(results2[0], 'r')
-    assert hasattr(results2[0].r, 'voltage')
+    assert isinstance(results2[0].r, (int, float))
 
 
 @pytest.mark.libngspice
@@ -265,7 +265,12 @@ def test_highlevel_async_parameter_sweep(backend):
                 break
 
         assert len(async_results) >= 1
+<<<<<<< HEAD:tests/test_sim2_async.py
         results[vin] = async_results[-1].o.voltage
+=======
+        # Store the final numeric value for comparison
+        results[vin] = async_results[-1].o
+>>>>>>> 2a47021 (simplify TransResult):tests/test_sim2_ffi_async.py
 
     assert len(results) == 3
     for vin in input_voltages:

--- a/tests/test_sim2_async.py
+++ b/tests/test_sim2_async.py
@@ -25,21 +25,23 @@ def test_highlevel_async_tran_basic(backend):
         data_points.append(result)
         time_values.append(result.time)
 
-        # Verify hierarchical access works; result.a is a numeric value representing the signal
-        assert hasattr(result, 'a')
-        assert isinstance(result.a, (int, float))
-        assert hasattr(result, 'time')
+        # Verify hierarchical access works; result.a is a SignalValue struct containing the signal
+        assert hasattr(result, "a")
+        assert hasattr(result.a, "value")
+        assert hasattr(result.a, "kind")
+        assert isinstance(result.a.value, (int, float))
+        assert hasattr(result, "time")
 
         # Break after collecting enough data
         if i >= 10:
             break
 
-    # Should have collected at least one time point (static circuits may only yield one)
     assert len(data_points) >= 1
+    assert len(time_values) >= 1
 
     # Time should be progressing
     for i in range(1, len(time_values)):
-        assert time_values[i] >= time_values[i-1]
+        assert time_values[i].value >= time_values[i - 1].value
 
 
 @pytest.mark.libngspice
@@ -48,23 +50,25 @@ def test_highlevel_async_tran_with_callback(backend):
     progress_updates = []
 
     def progress_callback(data_point):
-        progress_updates.append({
-            'progress': data_point.get('progress', data_point.get('index', 0)),
-            'current_time': data_point.get('timestamp', 0),
-            'data': data_point.get('data', {})
-        })
+        progress_updates.append(
+            {
+                "progress": data_point.get("progress", data_point.get("index", 0)),
+                "current_time": data_point.get("timestamp", 0),
+                "data": data_point.get("data", {}),
+            }
+        )
 
     h = lib_test.ResdivFlatTb(backend=backend)
 
     data_count = 0
-    for result in h.sim_tran_async("0.1u", "5u",
-                                   callback=progress_callback,
-                                   throttle_interval=0.1):
+    for result in h.sim_tran_async(
+        "0.1u", "5u", callback=progress_callback, throttle_interval=0.1
+    ):
         data_count += 1
 
         # Verify progress information is available
         assert 0.0 <= result.progress <= 1.0
-        assert result.time >= 0.0
+        assert result.time.value >= 0.0
 
         if data_count >= 8:
             break
@@ -74,7 +78,7 @@ def test_highlevel_async_tran_with_callback(backend):
 
     # Progress should be increasing
     for i in range(1, len(progress_updates)):
-        assert progress_updates[i]['progress'] >= progress_updates[i-1]['progress']
+        assert progress_updates[i]["progress"] >= progress_updates[i - 1]["progress"]
 
 
 @pytest.mark.libngspice
@@ -89,16 +93,25 @@ def test_sky130_streaming_without_savecurrents(backend):
         callback_count += 1
 
     data_points = []
-    for i, result in enumerate(h.sim_tran_async("0.01u", "0.5u",
-                                                enable_savecurrents=False,
-                                                callback=count_callback,
-                                                throttle_interval=0.05)):
+    for i, result in enumerate(
+        h.sim_tran_async(
+            "0.01u",
+            "0.5u",
+            enable_savecurrents=False,
+            callback=count_callback,
+            throttle_interval=0.05,
+        )
+    ):
         data_points.append(result)
         if i >= 5:
             break
 
-    assert len(data_points) >= 1, f"Expected at least 1 data point without savecurrents, got {len(data_points)}"
-    assert callback_count >= 1, f"Expected at least 1 callback without savecurrents, got {callback_count}"
+    assert len(data_points) >= 1, (
+        f"Expected at least 1 data point without savecurrents, got {len(data_points)}"
+    )
+    assert callback_count >= 1, (
+        f"Expected at least 1 callback without savecurrents, got {callback_count}"
+    )
 
 
 @pytest.mark.libngspice
@@ -113,16 +126,25 @@ def test_sky130_streaming_with_savecurrents(backend):
         callback_count += 1
 
     data_points = []
-    for i, result in enumerate(h.sim_tran_async("0.01u", "0.5u",
-                                                enable_savecurrents=True,
-                                                callback=count_callback,
-                                                throttle_interval=0.05)):
+    for i, result in enumerate(
+        h.sim_tran_async(
+            "0.01u",
+            "0.5u",
+            enable_savecurrents=True,
+            callback=count_callback,
+            throttle_interval=0.05,
+        )
+    ):
         data_points.append(result)
         if i >= 5:
             break
 
-    assert len(data_points) >= 1, f"Expected at least 1 data point with savecurrents, got {len(data_points)}"
-    assert callback_count >= 0, f"Expected non-negative callbacks with savecurrents, got {callback_count}"
+    assert len(data_points) >= 1, (
+        f"Expected at least 1 data point with savecurrents, got {len(data_points)}"
+    )
+    assert callback_count >= 0, (
+        f"Expected non-negative callbacks with savecurrents, got {callback_count}"
+    )
 
 
 @pytest.mark.libngspice
@@ -141,8 +163,12 @@ def test_sky130_netlist_savecurrents_option():
     sim_without = HighlevelSim(h.schematic, node2, enable_savecurrents=False)
     netlist_without = sim_without.netlister.out()
 
-    assert ".option savecurrents" in netlist_with, "Netlist with enable_savecurrents=True should contain .option savecurrents"
-    assert ".option savecurrents" not in netlist_without, "Netlist with enable_savecurrents=False should not contain .option savecurrents"
+    assert ".option savecurrents" in netlist_with, (
+        "Netlist with enable_savecurrents=True should contain .option savecurrents"
+    )
+    assert ".option savecurrents" not in netlist_without, (
+        "Netlist with enable_savecurrents=False should not contain .option savecurrents"
+    )
 
 
 @pytest.mark.libngspice
@@ -160,8 +186,10 @@ def test_highlevel_async_mos_sourcefollower(backend):
     assert len(data_points) >= 1
 
     final_result = data_points[-1]
-    assert hasattr(final_result, 'o')
-    assert isinstance(final_result.o, (int, float))
+    assert hasattr(final_result, "o")
+    assert hasattr(final_result.o, "value")
+    assert hasattr(final_result.o, "kind")
+    assert isinstance(final_result.o.value, (int, float))
 
 
 @pytest.mark.libngspice
@@ -179,8 +207,10 @@ def test_highlevel_async_mos_inverter(backend):
     assert len(data_points) >= 1
 
     final_result = data_points[-1]
-    assert hasattr(final_result, 'o')
-    assert isinstance(final_result.o, (int, float))
+    assert hasattr(final_result, "o")
+    assert hasattr(final_result.o, "value")
+    assert hasattr(final_result.o, "kind")
+    assert isinstance(final_result.o.value, (int, float))
 
 
 @pytest.mark.libngspice
@@ -189,7 +219,9 @@ def test_highlevel_async_sky_inverter(backend):
     h = lib_test.InvSkyTb(vin=R(2.5), backend=backend)
 
     data_points = []
-    for i, result in enumerate(h.sim_tran_async("0.1u", "1u", enable_savecurrents=False)):
+    for i, result in enumerate(
+        h.sim_tran_async("0.1u", "1u", enable_savecurrents=False)
+    ):
         data_points.append(result)
         if i >= 5:
             break
@@ -197,8 +229,10 @@ def test_highlevel_async_sky_inverter(backend):
     assert len(data_points) >= 1
 
     final_result = data_points[-1]
-    assert hasattr(final_result, 'o')
-    assert isinstance(final_result.o, (int, float))
+    assert hasattr(final_result, "o")
+    assert hasattr(final_result.o, "value")
+    assert hasattr(final_result.o, "kind")
+    assert isinstance(final_result.o.value, (int, float))
 
 
 @pytest.mark.libngspice
@@ -233,8 +267,10 @@ def test_highlevel_async_multiple_circuits(backend):
             break
 
     assert len(results1) >= 1
-    assert hasattr(results1[0], 'a')
-    assert isinstance(results1[0].a, (int, float))
+    assert hasattr(results1[0], "a")
+    assert hasattr(results1[0].a, "value")
+    assert hasattr(results1[0].a, "kind")
+    assert isinstance(results1[0].a.value, (int, float))
 
     # Second circuit
     h2 = lib_test.ResdivHierTb(backend=backend)
@@ -245,8 +281,10 @@ def test_highlevel_async_multiple_circuits(backend):
             break
 
     assert len(results2) >= 1
-    assert hasattr(results2[0], 'r')
-    assert isinstance(results2[0].r, (int, float))
+    assert hasattr(results2[0], "r")
+    assert hasattr(results2[0].r, "value")
+    assert hasattr(results2[0].r, "kind")
+    assert isinstance(results2[0].r.value, (int, float))
 
 
 @pytest.mark.libngspice
@@ -271,13 +309,14 @@ def test_highlevel_async_parameter_sweep(backend):
     assert len(results) == 3
     for vin in input_voltages:
         assert vin in results
-        assert isinstance(results[vin], (int, float))
+        assert hasattr(results[vin], "value")
+        assert hasattr(results[vin], "kind")
+        assert isinstance(results[vin].value, (int, float))
 
 
 @pytest.mark.libngspice
 @pytest.mark.parametrize("backend", ["subprocess", "ffi", "mp"])
 def test_async_alter_resume(backend):
-
     circuit = RCAlterTestbench()
     node = SimHierarchy()
     sim = HighlevelSim(circuit.schematic, node, backend=backend)
@@ -285,9 +324,10 @@ def test_async_alter_resume(backend):
     async def run_comprehensive_test():
         """Test multiple aspects of async alter functionality"""
         with sim.alter_session(backend=backend) as alter:
-
             # Start async transient simulation
-            data_queue = alter.start_async_tran("10u", "100m")  # 10us steps, 100ms total
+            data_queue = alter.start_async_tran(
+                "10u", "100m"
+            )  # 10us steps, 100ms total
             initial_data = []
             found_signals = set()
             mapped_signals = {}
@@ -297,16 +337,18 @@ def test_async_alter_resume(backend):
             while (time.time() - start_time) < timeout and len(initial_data) < 20:
                 try:
                     data_point = data_queue.get(timeout=0.1)
-                    if isinstance(data_point, dict) and 'data' in data_point:
-                        sim_time = data_point['data'].get('time', 0)
-                        data_dict = data_point['data']
+                    if isinstance(data_point, dict) and "data" in data_point:
+                        sim_time = data_point["data"].get("time", 0)
+                        data_dict = data_point["data"]
                         initial_data.append((sim_time, data_dict))
                         for signal_name in data_dict.keys():
-                            if signal_name != 'time':
+                            if signal_name != "time":
                                 found_signals.add(signal_name)
                                 if signal_name in sim.str_to_simobj:
                                     simnet = sim.str_to_simobj[signal_name]
-                                    net_name = simnet.eref.full_path_str().split('.')[-1]
+                                    net_name = simnet.eref.full_path_str().split(".")[
+                                        -1
+                                    ]
                                     mapped_signals[signal_name] = net_name
                         if sim_time >= 0.005:
                             break
@@ -322,52 +364,62 @@ def test_async_alter_resume(backend):
 
             for i, voltage in enumerate(voltage_sequence):
                 halt_success = alter.halt_simulation(timeout=2.0)
-                assert halt_success, f"Should successfully halt simulation at step {i+1}"
+                assert halt_success, (
+                    f"Should successfully halt simulation at step {i + 1}"
+                )
                 alter.alter_component(circuit.schematic.v1, dc=voltage)
                 vdc_info = alter.show_component(circuit.schematic.v1)
-                expected = str(int(voltage)) if voltage == int(voltage) else str(voltage)
-                assert expected in vdc_info, f"Step {i+1}: VDC should show {expected}V after alter: {vdc_info}"
+                expected = (
+                    str(int(voltage)) if voltage == int(voltage) else str(voltage)
+                )
+                assert expected in vdc_info, (
+                    f"Step {i + 1}: VDC should show {expected}V after alter: {vdc_info}"
+                )
                 resume_success = alter.resume_simulation(timeout=3.0)
-                assert resume_success, f"Should successfully resume simulation at step {i+1}"
+                assert resume_success, (
+                    f"Should successfully resume simulation at step {i + 1}"
+                )
                 step_data = []
                 step_start = time.time()
                 while (time.time() - step_start) < 1.0 and len(step_data) < 10:
                     try:
                         data_point = data_queue.get(timeout=0.1)
-                        if isinstance(data_point, dict) and 'data' in data_point:
-                            sim_time = data_point['data'].get('time', 0)
-                            step_data.append((sim_time, data_point['data']))
+                        if isinstance(data_point, dict) and "data" in data_point:
+                            sim_time = data_point["data"].get("time", 0)
+                            step_data.append((sim_time, data_point["data"]))
                     except queue.Empty:
                         continue
 
                 alter_data.extend(step_data)
-                assert len(step_data) > 0, f"Should collect data after alter step {i+1}"
+                assert len(step_data) > 0, (
+                    f"Should collect data after alter step {i + 1}"
+                )
 
             final_data = []
             start_time = time.time()
             while (time.time() - start_time) < 2.0 and len(final_data) < 10:
                 try:
                     data_point = data_queue.get(timeout=0.1)
-                    if isinstance(data_point, dict) and 'data' in data_point:
-                        sim_time = data_point['data'].get('time', 0)
-                        final_data.append((sim_time, data_point['data']))
+                    if isinstance(data_point, dict) and "data" in data_point:
+                        sim_time = data_point["data"].get("time", 0)
+                        final_data.append((sim_time, data_point["data"]))
                 except queue.Empty:
                     continue
 
             return {
-                'initial_points': len(initial_data),
-                'alter_points': len(alter_data),
-                'final_points': len(final_data),
-                'signal_count': len(found_signals),
-                'mapped_count': len(mapped_signals),
-                'voltage_steps': len(voltage_sequence)
+                "initial_points": len(initial_data),
+                "alter_points": len(alter_data),
+                "final_points": len(final_data),
+                "signal_count": len(found_signals),
+                "mapped_count": len(mapped_signals),
+                "voltage_steps": len(voltage_sequence),
             }
 
-
     import asyncio
+
     result = asyncio.run(run_comprehensive_test())
-    assert result['initial_points'] > 0, "Should collect initial data points"
-    assert result['alter_points'] > 0, "Should collect data after alterations"
-    assert result['signal_count'] >= 2, "Should detect multiple signals"
-    assert result['mapped_count'] >= 2, "Should map signal names correctly"
-    assert result['voltage_steps'] == 4, "Should complete all voltage alteration steps"
+    assert result["initial_points"] > 0, "Should collect initial data points"
+    assert result["alter_points"] > 0, "Should collect data after alterations"
+    assert result["signal_count"] >= 2, "Should detect multiple signals"
+    assert result["mapped_count"] >= 2, "Should map signal names correctly"
+    assert result["voltage_steps"] == 4, "Should complete all voltage alteration steps"

--- a/tests/test_sim2_async.py
+++ b/tests/test_sim2_async.py
@@ -265,26 +265,13 @@ def test_highlevel_async_parameter_sweep(backend):
                 break
 
         assert len(async_results) >= 1
-<<<<<<< HEAD:tests/test_sim2_async.py
-        results[vin] = async_results[-1].o.voltage
-=======
         # Store the final numeric value for comparison
         results[vin] = async_results[-1].o
->>>>>>> 2a47021 (simplify TransResult):tests/test_sim2_ffi_async.py
 
     assert len(results) == 3
     for vin in input_voltages:
         assert vin in results
         assert isinstance(results[vin], (int, float))
-
-
-
-
-
-
-
-
-
 
 
 @pytest.mark.libngspice


### PR DESCRIPTION
This pull request refactors the ngspice backend selection and signal handling in the simulation codebase, improves error visibility for FFI library loading, and introduces a new `SignalKind` system for more robust signal categorization. It also updates VCD export timescale formatting and cleans up legacy code references. These changes improve maintainability, debugging, and signal data access throughout the simulation modules.

### Backend selection and FFI initialization

* Replaces legacy backend class names (`_FFIBackend`, `_SubprocessBackend`, `IsolatedFFIBackend`) with new explicit names (`NgspiceFFI`, `NgspiceSubprocess`, `NgspiceIsolatedFFI`) throughout the codebase for clarity and consistency. [[1]](diffhunk://#diff-4b40e224b6d867179e0411504b01f0dfee234dfd1b4b64e284c04bd745611405L13-R15) [[2]](diffhunk://#diff-4b40e224b6d867179e0411504b01f0dfee234dfd1b4b64e284c04bd745611405L34-R36) [[3]](diffhunk://#diff-6dc00928cf2aefa78cd044a645649ec01b001a090da7d6b3e4f365061253f0e9L26-R28) [[4]](diffhunk://#diff-6dc00928cf2aefa78cd044a645649ec01b001a090da7d6b3e4f365061253f0e9L95-R95) [[5]](diffhunk://#diff-6dc00928cf2aefa78cd044a645649ec01b001a090da7d6b3e4f365061253f0e9L108-R108) [[6]](diffhunk://#diff-6dc00928cf2aefa78cd044a645649ec01b001a090da7d6b3e4f365061253f0e9L306-R306)
* Moves FFI library validation to module import time in example scripts (`example_rc_filter.py`, `interactive_rc_circuit.py`) to surface linker/load errors immediately for easier debugging. Removes redundant runtime checks. [[1]](diffhunk://#diff-e0c08d860c36311f7acc24c21f64ac6c9abead878498cd6bdb3204e1ce40b865R14-R16) [[2]](diffhunk://#diff-e0c08d860c36311f7acc24c21f64ac6c9abead878498cd6bdb3204e1ce40b865L242-R257) [[3]](diffhunk://#diff-591097f2df821ba6d477d311daea43316e349d3fb938c39da16626019f5458d1R17-R21) [[4]](diffhunk://#diff-591097f2df821ba6d477d311daea43316e349d3fb938c39da16626019f5458d1L73-R78)

### Signal categorization and data model improvements

* Introduces `SignalKind` enum and `SignalArray` dataclass to categorize signals (time, voltage, current, other) in simulation results, replacing plain lists and enhancing signal access and classification. Updates `NgspiceTransientResult` and `NgspiceAcResult` to use these structures. [[1]](diffhunk://#diff-4d687d7f66f67b70dd4ede2838f8a198d6ab47dad064d18728c6215ef483bdfeR6-R118) [[2]](diffhunk://#diff-4d687d7f66f67b70dd4ede2838f8a198d6ab47dad064d18728c6215ef483bdfeL44-R130) [[3]](diffhunk://#diff-4d687d7f66f67b70dd4ede2838f8a198d6ab47dad064d18728c6215ef483bdfeL83-R205) [[4]](diffhunk://#diff-4d687d7f66f67b70dd4ede2838f8a198d6ab47dad064d18728c6215ef483bdfeL143-R337)
* Adds robust signal kind guessing heuristics for both transient and AC results, improving downstream analysis and plotting. [[1]](diffhunk://#diff-4d687d7f66f67b70dd4ede2838f8a198d6ab47dad064d18728c6215ef483bdfeL83-R205) [[2]](diffhunk://#diff-4d687d7f66f67b70dd4ede2838f8a198d6ab47dad064d18728c6215ef483bdfeL143-R337)

### API consistency and improvements

* Updates `tran_async` method signature to require explicit `tstep` and optional `tstop`, enforcing strict parameter forwarding to backend implementations for consistency.

### VCD export and formatting

* Changes VCD export timescale arguments from `"1us"` to `"1u"` for consistency and compatibility in both example scripts. Updates docstrings accordingly. [[1]](diffhunk://#diff-e0c08d860c36311f7acc24c21f64ac6c9abead878498cd6bdb3204e1ce40b865L271-R275) [[2]](diffhunk://#diff-591097f2df821ba6d477d311daea43316e349d3fb938c39da16626019f5458d1L286-R296) [[3]](diffhunk://#diff-591097f2df821ba6d477d311daea43316e349d3fb938c39da16626019f5458d1L406-R410)

### Minor fixes and cleanup

* Standardizes string quoting (single to double quotes) and improves signal name parsing logic for categorization and plotting. [[1]](diffhunk://#diff-4d687d7f66f67b70dd4ede2838f8a198d6ab47dad064d18728c6215ef483bdfeL44-R130) [[2]](diffhunk://#diff-4d687d7f66f67b70dd4ede2838f8a198d6ab47dad064d18728c6215ef483bdfeL67-R153) [[3]](diffhunk://#diff-4d687d7f66f67b70dd4ede2838f8a198d6ab47dad064d18728c6215ef483bdfeL83-R205) [[4]](diffhunk://#diff-4d687d7f66f67b70dd4ede2838f8a198d6ab47dad064d18728c6215ef483bdfeL123-R225) [[5]](diffhunk://#diff-4d687d7f66f67b70dd4ede2838f8a198d6ab47dad064d18728c6215ef483bdfeL143-R337)