### PR TITLE
Expose helper to resolve IHP PDK path with fallback

### DIFF
--- a/examples/dev/layout.py
+++ b/examples/dev/layout.py
@@ -1,9 +1,7 @@
-import os
-from pathlib import Path
 import ordec.layout
 from ordec.core import *
 
-ihp_path = Path(os.getenv("ORDEC_PDK_IHP_SG13G2"))
+ihp_path = ordec.layout.get_ihp_pdk_path()
 
 @generate_func
 def layout_xor() -> Layout:

--- a/ordec/layout/__init__.py
+++ b/ordec/layout/__init__.py
@@ -3,4 +3,12 @@
 
 from .read_gds import read_gds
 from .ihp130 import SG13G2
+from ..lib.ihp130 import get_ihp_pdk_path
 from .webdata import layout_webdata
+
+__all__ = [
+    "get_ihp_pdk_path",
+    "read_gds",
+    "SG13G2",
+    "layout_webdata",
+]

--- a/ordec/lib/ihp130.py
+++ b/ordec/lib/ihp130.py
@@ -27,8 +27,7 @@ def get_ihp_pdk_path() -> Path:
     if env_var_path:
         return Path(env_var_path)
 
-    module_dir = Path(__file__).parent
-    project_root = module_dir.parent.parent
+    project_root = Path(__file__).resolve().parents[2]
     return project_root / "ihp-sg13g2"
 
 

--- a/ordec/lib/ihp130.py
+++ b/ordec/lib/ihp130.py
@@ -12,17 +12,27 @@ from ..ord1.implicit_processing import schematic_routing
 from ..sim2.ngspice_common import NgspiceError
 from . import generic_mos
 
-def _get_ihp_pdk_path():
-    """Helper function to determine the IHP PDK path."""
+
+@public
+def get_ihp_pdk_path() -> Path:
+    """Return the path to the bundled IHP SG13G2 PDK.
+
+    The location can be overridden by the ``ORDEC_PDK_IHP_SG13G2`` environment
+    variable. When the variable is not set, the repository copy under
+    ``ihp-sg13g2`` is used.  The returned path may be used by consumers that
+    need access to PDK assets without replicating the fallback logic.
+    """
+
     env_var_path = os.getenv("ORDEC_PDK_IHP_SG13G2")
     if env_var_path:
         return Path(env_var_path)
-    else:
-        _MODULE_DIR = Path(__file__).parent
-        _PROJECT_ROOT = _MODULE_DIR.parent.parent
-        return _PROJECT_ROOT / "ihp-sg13g2"
 
-_IHP_PDK_PATH = _get_ihp_pdk_path()
+    module_dir = Path(__file__).parent
+    project_root = module_dir.parent.parent
+    return project_root / "ihp-sg13g2"
+
+
+_IHP_PDK_PATH = get_ihp_pdk_path()
 _IHP_SG13G2_RELATIVE_MODEL_PATH = "libs.tech/ngspice/models/cornerMOSlv.lib"
 _IHP_SG13G2_MODEL_FULL_PATH = (_IHP_PDK_PATH / _IHP_SG13G2_RELATIVE_MODEL_PATH).resolve()
 

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1,12 +1,11 @@
 # SPDX-FileCopyrightText: 2025 ORDeC contributors
 # SPDX-License-Identifier: Apache-2.0
 
-import os
-from pathlib import Path
 import ordec.layout
 
+
 def test_read_gds():
-    ihp_path = Path(os.getenv("ORDEC_PDK_IHP_SG13G2"))
+    ihp_path = ordec.layout.get_ihp_pdk_path()
     gds_fn = ihp_path / "libs.ref/sg13g2_stdcell/gds/sg13g2_stdcell.gds"
     x = ordec.layout.read_gds(gds_fn, ordec.layout.SG13G2().layers, 'sg13g2_xor2_1')
     print(x)


### PR DESCRIPTION
## Summary
- add a public helper that locates the IHP SG13G2 PDK using the environment variable or the bundled copy
- export the helper through `ordec.layout` and update layout tests and examples to rely on it

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f7e75d5fd0832ab5cb0a0ba61b0ab4

## Summary by Sourcery

Add a public helper to locate the IHP SG13G2 PDK path with optional environment override and use it across the layout package

New Features:
- Introduce get_ihp_pdk_path to resolve the IHP SG13G2 PDK path using ORDEC_PDK_IHP_SG13G2 or the bundled copy

Enhancements:
- Export get_ihp_pdk_path in the ordec.layout module
- Update layout tests and examples to use the new helper instead of manual path handling