### PR TITLE
Increase ngspice subprocess precision

### DIFF
--- a/ordec/sim2/ngspice_subprocess.py
+++ b/ordec/sim2/ngspice_subprocess.py
@@ -32,6 +32,7 @@ from .ngspice_common import (
     SignalKind,
     SignalArray,
     NgspiceBase,
+    NgspiceConfigError,
 )
 
 NgspiceVector = namedtuple(
@@ -96,6 +97,21 @@ class NgspiceSubprocess(NgspiceBase):
         self._wrdata_file: Optional[Path] = None
         self._wrdata_last_row = 0
         self._wrdata_vectors: list[str] = []
+
+        self._configure_precision()
+
+    def _configure_precision(self) -> None:
+        """Configure ngspice numeric precision settings."""
+
+        try:
+            if self.debug:
+                print("[debug] Configuring ngspice numeric precision")
+            # Increase the number of digits printed in tabular outputs.
+            self.command("set numdgt=16")
+            # Ensure computed scalar values use the same precision.
+            self.command("set csnumprec=16")
+        except NgspiceError as exc:
+            raise NgspiceConfigError("Failed to configure ngspice precision") from exc
 
     def command(self, command: str) -> str:
         """Executes ngspice command and returns string output from ngspice process."""

--- a/ordec/sim2/ngspice_subprocess.py
+++ b/ordec/sim2/ngspice_subprocess.py
@@ -106,9 +106,7 @@ class NgspiceSubprocess(NgspiceBase):
         try:
             if self.debug:
                 print("[debug] Configuring ngspice numeric precision")
-            # Increase the number of digits printed in tabular outputs.
             self.command("set numdgt=16")
-            # Ensure computed scalar values use the same precision.
             self.command("set csnumprec=16")
         except NgspiceError as exc:
             raise NgspiceConfigError("Failed to configure ngspice precision") from exc

--- a/tests/test_sim2.py
+++ b/tests/test_sim2.py
@@ -77,7 +77,7 @@ def test_ngspice_op_no_auto_gnd(backend):
     assert op['gnd'] == 1.0
 
 @pytest.mark.parametrize("backend,golden_a,golden_b", [
-    ('subprocess', 0.3333333, 0.6666667),
+    ('subprocess', 0.33333333333333337, 0.6666666666666667),
     pytest.param('ffi', 0.33333333333333337, 0.6666666666666667, marks=pytest.mark.libngspice),
     pytest.param('mp', 0.33333333333333337, 0.6666666666666667, marks=pytest.mark.libngspice),
 ])
@@ -89,7 +89,7 @@ def test_sim_dc_flat(backend, golden_a, golden_b):
 
 
 @pytest.mark.parametrize("backend,golden_r,golden_m", [
-    ('subprocess', 0.3589744, 0.5897436),
+    ('subprocess', 0.3589743589743596, 0.5897435897435901),
     pytest.param('ffi', 0.3589743589743596, 0.5897435897435901, marks=pytest.mark.libngspice),
     pytest.param('mp', 0.3589743589743596, 0.5897435897435901, marks=pytest.mark.libngspice),
 ])
@@ -108,7 +108,7 @@ def test_generic_mos_netlister():
     assert netlist.count('.model pmosgeneric PMOS level=1') == 1
 
 @pytest.mark.parametrize("backend,golden_2,golden_3", [
-    ('subprocess', 0.6837722, 1.683772),
+    ('subprocess', 0.6837722116612965, 1.6837721784225057),
     pytest.param('ffi', 0.6837722116612965, 1.6837721784225057, marks=pytest.mark.libngspice),
     pytest.param('mp', 0.6837722116612965, 1.6837721784225057, marks=pytest.mark.libngspice),
 ])
@@ -117,7 +117,7 @@ def test_generic_mos_nmos_sourcefollower(backend, golden_2, golden_3):
     assert lib_test.NmosSourceFollowerTb(vin=R(3), backend=backend).sim_dc.o.dc_voltage == golden_3
 
 @pytest.mark.parametrize("backend,golden_0,golden_2_5,golden_5", [
-    ('subprocess', 5.0, 2.5, 3.13125e-08),
+    ('subprocess', 4.9999999698343345, 2.500000017115547, 3.131249965532494e-08),
     pytest.param('ffi', 4.9999999698343345, 2.500000017115547, 3.131249965532494e-08, marks=pytest.mark.libngspice),
     pytest.param('mp', 4.9999999698343345, 2.500000017115547, 3.131249965532494e-08, marks=pytest.mark.libngspice),
 ])
@@ -127,7 +127,7 @@ def test_generic_mos_inv(backend, golden_0, golden_2_5, golden_5):
     assert lib_test.InvTb(vin=R(5), backend=backend).sim_dc.o.dc_voltage == golden_5
 
 @pytest.mark.parametrize("backend,golden_0,golden_2_5,golden_5", [
-    ('subprocess', 5.0, 1.980606, 0.00012159),
+    ('subprocess', 4.999999973187308, 1.9806063550640076, 0.00012158997833462999),
     pytest.param('ffi', 4.999999973187308, 1.9806063550640076, 0.00012158997833462999, marks=pytest.mark.libngspice),
     pytest.param('mp', 4.999999973187308, 1.9806063550640076, 0.00012158997833462999, marks=pytest.mark.libngspice),
 ])

--- a/tests/test_sim2.py
+++ b/tests/test_sim2.py
@@ -76,28 +76,18 @@ def test_ngspice_op_no_auto_gnd(backend):
     assert op['a'] == 2.0
     assert op['gnd'] == 1.0
 
-@pytest.mark.parametrize("backend,golden_a,golden_b", [
-    ('subprocess', 0.33333333333333337, 0.6666666666666667),
-    pytest.param('ffi', 0.33333333333333337, 0.6666666666666667, marks=pytest.mark.libngspice),
-    pytest.param('mp', 0.33333333333333337, 0.6666666666666667, marks=pytest.mark.libngspice),
-])
-def test_sim_dc_flat(backend, golden_a, golden_b):
+@pytest.mark.parametrize("backend", sim2_backends)
+def test_sim_dc_flat(backend):
     h = lib_test.ResdivFlatTb(backend=backend).sim_dc
-    # Note: FFI backend has different golden values
-    assert h.a.dc_voltage == golden_a
-    assert h.b.dc_voltage == golden_b
+    assert h.a.dc_voltage == 0.33333333333333337
+    assert h.b.dc_voltage == 0.6666666666666667
 
 
-@pytest.mark.parametrize("backend,golden_r,golden_m", [
-    ('subprocess', 0.3589743589743596, 0.5897435897435901),
-    pytest.param('ffi', 0.3589743589743596, 0.5897435897435901, marks=pytest.mark.libngspice),
-    pytest.param('mp', 0.3589743589743596, 0.5897435897435901, marks=pytest.mark.libngspice),
-])
-def test_sim_dc_hier(backend, golden_r, golden_m):
+@pytest.mark.parametrize("backend", sim2_backends)
+def test_sim_dc_hier(backend):
     h = lib_test.ResdivHierTb(backend=backend).sim_dc
-    # Note: FFI backend has different golden values
-    assert abs(h.r.dc_voltage - golden_r) < 1e-10
-    assert abs(h.I0.I1.m.dc_voltage - golden_m) < 1e-10
+    assert abs(h.r.dc_voltage - 0.3589743589743596) < 1e-10
+    assert abs(h.I0.I1.m.dc_voltage - 0.5897435897435901) < 1e-10
 
 def test_generic_mos_netlister():
     nl = Netlister()
@@ -107,52 +97,32 @@ def test_generic_mos_netlister():
     assert netlist.count('.model nmosgeneric NMOS level=1') == 1
     assert netlist.count('.model pmosgeneric PMOS level=1') == 1
 
-@pytest.mark.parametrize("backend,golden_2,golden_3", [
-    ('subprocess', 0.6837722116612965, 1.6837721784225057),
-    pytest.param('ffi', 0.6837722116612965, 1.6837721784225057, marks=pytest.mark.libngspice),
-    pytest.param('mp', 0.6837722116612965, 1.6837721784225057, marks=pytest.mark.libngspice),
-])
-def test_generic_mos_nmos_sourcefollower(backend, golden_2, golden_3):
-    assert lib_test.NmosSourceFollowerTb(vin=R(2), backend=backend).sim_dc.o.dc_voltage == golden_2
-    assert lib_test.NmosSourceFollowerTb(vin=R(3), backend=backend).sim_dc.o.dc_voltage == golden_3
+@pytest.mark.parametrize("backend", sim2_backends)
+def test_generic_mos_nmos_sourcefollower(backend):
+    assert lib_test.NmosSourceFollowerTb(vin=R(2), backend=backend).sim_dc.o.dc_voltage == 0.6837722116612965
+    assert lib_test.NmosSourceFollowerTb(vin=R(3), backend=backend).sim_dc.o.dc_voltage == 1.6837721784225057
 
-@pytest.mark.parametrize("backend,golden_0,golden_2_5,golden_5", [
-    ('subprocess', 4.9999999698343345, 2.500000017115547, 3.131249965532494e-08),
-    pytest.param('ffi', 4.9999999698343345, 2.500000017115547, 3.131249965532494e-08, marks=pytest.mark.libngspice),
-    pytest.param('mp', 4.9999999698343345, 2.500000017115547, 3.131249965532494e-08, marks=pytest.mark.libngspice),
-])
-def test_generic_mos_inv(backend, golden_0, golden_2_5, golden_5):
-    assert lib_test.InvTb(vin=R(0), backend=backend).sim_dc.o.dc_voltage == golden_0
-    assert lib_test.InvTb(vin=R('2.5'), backend=backend).sim_dc.o.dc_voltage == golden_2_5
-    assert lib_test.InvTb(vin=R(5), backend=backend).sim_dc.o.dc_voltage == golden_5
+@pytest.mark.parametrize("backend", sim2_backends)
+def test_generic_mos_inv(backend):
+    assert lib_test.InvTb(vin=R(0), backend=backend).sim_dc.o.dc_voltage == 4.9999999698343345
+    assert lib_test.InvTb(vin=R('2.5'), backend=backend).sim_dc.o.dc_voltage == 2.500000017115547
+    assert lib_test.InvTb(vin=R(5), backend=backend).sim_dc.o.dc_voltage == 3.131249965532494e-08
 
-@pytest.mark.parametrize("backend,golden_0,golden_2_5,golden_5", [
-    ('subprocess', 4.999999973187308, 1.9806063550640076, 0.00012158997833462999),
-    pytest.param('ffi', 4.999999973187308, 1.9806063550640076, 0.00012158997833462999, marks=pytest.mark.libngspice),
-    pytest.param('mp', 4.999999973187308, 1.9806063550640076, 0.00012158997833462999, marks=pytest.mark.libngspice),
-])
-def test_sky_mos_inv(backend, golden_0, golden_2_5, golden_5):
-    assert abs(lib_test.InvSkyTb(vin=R(0), backend=backend).sim_dc.o.dc_voltage - golden_0) < 1e-10
-    assert abs(lib_test.InvSkyTb(vin=R('2.5'), backend=backend).sim_dc.o.dc_voltage - golden_2_5) < 1e-10
-    assert abs(lib_test.InvSkyTb(vin=R(5), backend=backend).sim_dc.o.dc_voltage - golden_5) < 1e-10
+@pytest.mark.parametrize("backend", sim2_backends)
+def test_sky_mos_inv(backend):
+    assert abs(lib_test.InvSkyTb(vin=R(0), backend=backend).sim_dc.o.dc_voltage - 4.999999973187308) < 1e-10
+    assert abs(lib_test.InvSkyTb(vin=R('2.5'), backend=backend).sim_dc.o.dc_voltage - 1.9806063550640076) < 1e-10
+    assert abs(lib_test.InvSkyTb(vin=R(5), backend=backend).sim_dc.o.dc_voltage - 0.00012158997833462999) < 1e-10
 
-@pytest.mark.parametrize("backend,golden", [
-    ('subprocess', 4.999573),
-    pytest.param('ffi', 4.9995727, marks=pytest.mark.libngspice),
-    pytest.param('mp', 4.9995727, marks=pytest.mark.libngspice),
-])
-def test_ihp_mos_inv_vin0(backend, golden):
+@pytest.mark.parametrize("backend", sim2_backends)
+def test_ihp_mos_inv_vin0(backend):
     h_0 = lib_test.InvIhpTb(vin=R(0), backend=backend).sim_dc
-    assert h_0.o.dc_voltage == pytest.approx(golden)
+    assert h_0.o.dc_voltage == pytest.approx(4.999573)
 
-@pytest.mark.parametrize("backend,golden", [
-    ('subprocess', 0.00024556),
-    pytest.param('ffi', 0.00024556, marks=pytest.mark.libngspice),
-    pytest.param('mp', 0.00024556, marks=pytest.mark.libngspice),
-])
-def test_ihp_mos_inv_vin5(backend, golden):
+@pytest.mark.parametrize("backend", sim2_backends)
+def test_ihp_mos_inv_vin5(backend):
     h_5 = lib_test.InvIhpTb(vin=R(5), backend=backend).sim_dc
-    assert h_5.o.dc_voltage == pytest.approx(golden, abs=1e-5)
+    assert h_5.o.dc_voltage == pytest.approx(0.00024556, abs=1e-5)
 
 @pytest.mark.parametrize("backend,golden_a,golden_b,atol", [
     ('subprocess', 0.3333333, 0.6666667, 1e-6),


### PR DESCRIPTION
## Summary
- configure the ngspice subprocess backend to request 16-digit numeric precision
- refresh subprocess golden expectations in simulation tests to match the higher precision output

## Testing
- pytest tests/test_sim2.py

------
https://chatgpt.com/codex/tasks/task_e_68fbe20f80d4832ab51a0d897dbc9c91

## Summary by Sourcery

Increase numeric precision for the ngspice subprocess backend by setting numdgt and csnumprec to 16, and update related simulation tests with new expected values

Enhancements:
- Configure ngspice subprocess backend to request 16-digit numeric precision
- Raise NgspiceConfigError if precision configuration fails

Tests:
- Refresh subprocess backend golden values in simulation tests to match higher precision outputs