### PR TITLE
Fix async halt synchronization for ngspice backends

### DIFF
--- a/ordec/sim2/ngspice_ffi.py
+++ b/ordec/sim2/ngspice_ffi.py
@@ -890,37 +890,48 @@ class NgspiceFFI(NgspiceBase):
         else:
             return True
 
+    def _read_running_state(self) -> Optional[bool]:
+        try:
+            return bool(self.lib.ngSpice_running())
+        except AttributeError:
+            if self.debug:
+                _debug("ngSpice_running unavailable; assuming simulation halted")
+            return None
+        except Exception as exc:  # pragma: no cover - defensive fallback
+            if self.debug:
+                _debug(f"ngSpice_running check failed: {exc}")
+            return bool(self._is_running)
+
     def safe_halt_simulation(
         self, max_attempts: int = 3, wait_time: float = 0.2
     ) -> bool:
         if not self._is_running:
             return True
 
-        for attempt in range(max_attempts):
+        for _ in range(max_attempts):
             self.command("bg_halt")
             deadline = time.time() + wait_time
 
             while time.time() < deadline:
-                try:
-                    is_running = bool(self.lib.ngSpice_running())
-                except Exception:
-                    is_running = self._is_running
+                is_running = self._read_running_state()
 
-                if not is_running:
+                if is_running is False:
+                    self._is_running = False
+                    return True
+
+                if is_running is None:
                     self._is_running = False
                     return True
 
                 time.sleep(min(0.05, wait_time / 5))
 
-        try:
-            is_running = bool(self.lib.ngSpice_running())
-        except Exception:
-            is_running = self._is_running
+        final_state = self._read_running_state()
 
-        if not is_running:
+        if final_state is False or final_state is None:
             self._is_running = False
+            return True
 
-        return not is_running
+        return False
 
     def halt_simulation(self, timeout: float = 2.0) -> bool:
         result = self.safe_halt_simulation(

--- a/ordec/sim2/ngspice_ffi.py
+++ b/ordec/sim2/ngspice_ffi.py
@@ -898,13 +898,29 @@ class NgspiceFFI(NgspiceBase):
 
         for attempt in range(max_attempts):
             self.command("bg_halt")
+            deadline = time.time() + wait_time
+
+            while time.time() < deadline:
+                try:
+                    is_running = bool(self.lib.ngSpice_running())
+                except Exception:
+                    is_running = self._is_running
+
+                if not is_running:
+                    self._is_running = False
+                    return True
+
+                time.sleep(min(0.05, wait_time / 5))
+
+        try:
+            is_running = bool(self.lib.ngSpice_running())
+        except Exception:
+            is_running = self._is_running
+
+        if not is_running:
             self._is_running = False
 
-            time.sleep(wait_time)
-            if not self._is_running:
-                return True
-
-        return not self._is_running
+        return not is_running
 
     def halt_simulation(self, timeout: float = 2.0) -> bool:
         result = self.safe_halt_simulation(

--- a/ordec/sim2/ngspice_subprocess.py
+++ b/ordec/sim2/ngspice_subprocess.py
@@ -415,18 +415,21 @@ class NgspiceSubprocess(NgspiceBase):
             self._async_halt_requested = True
             self._async_resume_event.clear()
 
+        self.command("bg_halt")
+
         # Wait for the async thread to observe the halt flag and enter the
         # paused state.  The worker thread sets ``_is_running`` to ``False``
         # once it finishes any in-flight ngspice command and starts waiting on
         # ``_async_resume_event``.  Until that happens, ngspice may still be
         # executing a long-running "step" command, so callers must not issue
         # additional control commands.
-        for attempt in range(max_attempts):
-            deadline = time.time() + wait_time
-            while time.time() < deadline:
-                if not self.is_running():
-                    return True
-                time.sleep(min(0.05, wait_time / 5))
+        deadline = time.time() + (max_attempts * wait_time)
+        poll_interval = min(0.05, wait_time / 5) if wait_time else 0.05
+
+        while time.time() < deadline:
+            if not self.is_running():
+                return True
+            time.sleep(poll_interval)
 
         if self.debug:
             _debug("safe_halt_simulation timed out waiting for async thread")

--- a/ordec/sim2/ngspice_subprocess.py
+++ b/ordec/sim2/ngspice_subprocess.py
@@ -408,13 +408,30 @@ class NgspiceSubprocess(NgspiceBase):
         self, max_attempts: int = 3, wait_time: float = 0.2
     ) -> bool:
         """Halt simulation by setting halt flag and clearing resume event."""
+        if self._async_thread is None:
+            return True
+
         with self._async_lock:
             self._async_halt_requested = True
             self._async_resume_event.clear()
-            self._is_running = False
 
-        time.sleep(wait_time)
-        return True
+        # Wait for the async thread to observe the halt flag and enter the
+        # paused state.  The worker thread sets ``_is_running`` to ``False``
+        # once it finishes any in-flight ngspice command and starts waiting on
+        # ``_async_resume_event``.  Until that happens, ngspice may still be
+        # executing a long-running "step" command, so callers must not issue
+        # additional control commands.
+        for attempt in range(max_attempts):
+            deadline = time.time() + wait_time
+            while time.time() < deadline:
+                if not self.is_running():
+                    return True
+                time.sleep(min(0.05, wait_time / 5))
+
+        if self.debug:
+            _debug("safe_halt_simulation timed out waiting for async thread")
+
+        return not self.is_running()
 
     def resume_simulation(self, timeout: float = 3.0) -> bool:
         """Resume simulation by clearing halt flag and setting resume event."""


### PR DESCRIPTION
## Summary
- make the subprocess safe_halt_simulation wait for the worker thread to acknowledge the halt request
- update the FFI backend to poll ngSpice_running before clearing its running flag so control commands are not sent while ngspice is busy
- retain existing resume logic while improving robustness of halt detection across backends

## Testing
- export ORDEC_PDK_IHP_SG13G2=$(pwd)/ihp-sg13g2
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68fc0fd6c8e4832ab4c7926d776cc5bc

## Summary by Sourcery

Improve halt synchronization across ngSpice backends by waiting for the simulation to actually stop before clearing running flags or issuing further control commands

Enhancements:
- Poll ngSpice_running in the FFI backend to clear the running flag only after the simulation stops
- Wait for the worker thread to acknowledge halt requests in the subprocess backend, polling is_running() and logging on timeouts
- Return immediately when no asynchronous thread is present to simplify halt logic in the subprocess backend